### PR TITLE
Reinstate build-and-push github workflow

### DIFF
--- a/.github/workflows/on-push-main.yaml
+++ b/.github/workflows/on-push-main.yaml
@@ -1,0 +1,27 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: hicsail/damplab-ui
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
# Description

Previously the deployment was moved to NERC as part of a wider SAIL push. So building was done on OpenShift. Now it is moving to AWS because HIPAA. So we are going back to building with GitHub workflows and pushing to Dockerhub. I have updated and simplified the actions while we're at it. 

In this repo, workflows seem to be organized around the triggering events rather than end goals, so I've kept it that way - the 'on PR' workflow has been left alone and this one is only on push to main.

## Checklist

- [x ] This PR can be reviewed in under 30 minutes
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have assigned reviewers to this PR.
