### PR TITLE
Pricing fields in backend

### DIFF
--- a/src/services/models/damplab-service.model.ts
+++ b/src/services/models/damplab-service.model.ts
@@ -50,10 +50,11 @@ export class DampLabService {
   description: string;
 
   @Prop({ required: false })
-  @Field(() => Float, { 
+  @Field(() => Float, {
     nullable: true,
-    description: 'The approximate cost to use this service.' })
-    price?: number;
+    description: 'The approximate cost to use this service.'
+  })
+  price?: number;
 }
 
 export type DampLabServiceDocument = DampLabService & Document;

--- a/src/services/models/damplab-service.model.ts
+++ b/src/services/models/damplab-service.model.ts
@@ -1,6 +1,6 @@
 import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
-import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { Field, ID, ObjectType, Float } from '@nestjs/graphql';
 import JSON from 'graphql-type-json';
 import mongoose from 'mongoose';
 
@@ -48,6 +48,12 @@ export class DampLabService {
   @Prop()
   @Field()
   description: string;
+
+  @Prop({ required: false })
+  @Field(() => Float, { 
+    nullable: true,
+    description: 'The approximate cost to use this service.' })
+    price?: number;
 }
 
 export type DampLabServiceDocument = DampLabService & Document;


### PR DESCRIPTION
## Description
> Backend changes for new edit, checkout, and final_checkout pages. 

## Changes included
- in `service.model.ts`: added price, which is optional, to allow for imported service database. Added type to float. These fields account for both the approximate cost of service and null/unknown price of service. 