### PR TITLE
feat: add job archive/unarchive backend support

### DIFF
--- a/src/job/dto/jobs-query.dto.ts
+++ b/src/job/dto/jobs-query.dto.ts
@@ -59,6 +59,9 @@ export class AllJobsInput {
 
   @Field(() => SortOrder, { description: 'Sort order (default DESC = latest first)', nullable: true })
   sortOrder?: SortOrder;
+
+  @Field({ description: 'Archive filter: ACTIVE (default, non-archived), ARCHIVED (archived only), or ALL', nullable: true })
+  archiveFilter?: string;
 }
 
 @ObjectType()

--- a/src/job/job.dto.ts
+++ b/src/job/job.dto.ts
@@ -17,7 +17,7 @@ export interface CreateJobPreProcessed extends Pick<Job, 'name' | 'institute' | 
 }
 
 // CreateJobFull is what the job service receives.
-export interface CreateJobFull extends Omit<Job, '_id' | 'workflows' | 'submitted' | 'jobId'> {
+export interface CreateJobFull extends Omit<Job, '_id' | 'workflows' | 'submitted' | 'jobId' | 'isArchived' | 'archivedAt' | 'archivedBy' | 'archivedFromState'> {
   workflows: AddWorkflowInputFull[];
 }
 

--- a/src/job/job.model.ts
+++ b/src/job/job.model.ts
@@ -136,6 +136,22 @@ export class Job {
     nullable: 'itemsAndList'
   })
   attachments?: JobAttachment[];
+
+  @Prop({ type: Boolean, default: false })
+  @Field({ description: 'Whether the job has been archived by staff', defaultValue: false })
+  isArchived: boolean;
+
+  @Prop({ type: Date, required: false })
+  @Field({ description: 'When the job was archived', nullable: true })
+  archivedAt?: Date;
+
+  @Prop({ type: String, required: false })
+  @Field({ description: 'Username of staff member who archived the job', nullable: true })
+  archivedBy?: string;
+
+  @Prop({ type: String, required: false })
+  @Field({ description: 'Job state at the time of archiving', nullable: true })
+  archivedFromState?: string;
 }
 
 export type JobDocument = Job & Document;
@@ -143,3 +159,4 @@ export const JobSchema = SchemaFactory.createForClass(Job);
 
 // Unique among jobs that have a display id; sparse so many legacy docs without jobId do not conflict.
 JobSchema.index({ jobId: 1 }, { unique: true, sparse: true });
+JobSchema.index({ isArchived: 1, state: 1 });

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -324,6 +324,35 @@ export class JobResolver {
     return (await this.jobService.updateState(job, newState))!;
   }
 
+  @Mutation(() => Job, {
+    description: 'Staff-only. Archive a job so it is hidden from the Lab Monitor and Dashboard active view.'
+  })
+  @Roles(Role.DamplabStaff)
+  async archiveJob(
+    @Args('jobId', { type: () => ID }) jobId: string,
+    @CurrentUser() user: User
+  ): Promise<Job> {
+    const updated = await this.jobService.archiveJob(jobId, user.preferred_username ?? user.email);
+    if (!updated) {
+      throw new NotFoundException(`Job with ID ${jobId} not found`);
+    }
+    return updated;
+  }
+
+  @Mutation(() => Job, {
+    description: 'Staff-only. Restore an archived job so it reappears on the Lab Monitor and Dashboard.'
+  })
+  @Roles(Role.DamplabStaff)
+  async unarchiveJob(
+    @Args('jobId', { type: () => ID }) jobId: string
+  ): Promise<Job> {
+    const updated = await this.jobService.unarchiveJob(jobId);
+    if (!updated) {
+      throw new NotFoundException(`Job with ID ${jobId} not found`);
+    }
+    return updated;
+  }
+
   @ResolveField()
   async workflows(@Parent() job: Job): Promise<Workflow[]> {
     return this.workflowService.findByIds(job.workflows.map((workflow) => workflow._id));

--- a/src/job/job.service.ts
+++ b/src/job/job.service.ts
@@ -86,12 +86,40 @@ export class JobService {
   async getWorkflowIdsForApprovedJobs(): Promise<mongoose.Types.ObjectId[]> {
     const approvedStates = [JobState.ACCEPTED, JobState.WAITING_FOR_SOW, JobState.QUEUED, JobState.IN_PROGRESS, JobState.COMPLETE];
     const jobs = await this.jobModel
-      .find({ state: { $in: approvedStates } })
+      .find({ state: { $in: approvedStates }, isArchived: { $ne: true } })
       .select('workflows')
       .lean()
       .exec();
     const ids = jobs.flatMap((j) => (j.workflows ?? []) as mongoose.Types.ObjectId[]);
     return [...new Set(ids)];
+  }
+
+  async archiveJob(jobId: string, archivedBy: string): Promise<Job | null> {
+    const job = await this.jobModel.findById(jobId).exec();
+    if (!job) return null;
+    return this.jobModel.findOneAndUpdate(
+      { _id: jobId },
+      {
+        $set: {
+          isArchived: true,
+          archivedAt: new Date(),
+          archivedBy,
+          archivedFromState: String(job.state)
+        }
+      },
+      { new: true }
+    ).exec();
+  }
+
+  async unarchiveJob(jobId: string): Promise<Job | null> {
+    return this.jobModel.findOneAndUpdate(
+      { _id: jobId },
+      {
+        $set: { isArchived: false },
+        $unset: { archivedAt: 1, archivedBy: 1, archivedFromState: 1 }
+      },
+      { new: true }
+    ).exec();
   }
 
   async updateState(job: Job, newState: JobState): Promise<Job | null> {
@@ -170,6 +198,12 @@ export class JobService {
     }
     if (input.state != null) {
       match.push({ state: input.state });
+    }
+    const archiveFilter = (input as AllJobsInput).archiveFilter ?? 'ACTIVE';
+    if (archiveFilter === 'ACTIVE') {
+      match.push({ isArchived: { $ne: true } });
+    } else if (archiveFilter === 'ARCHIVED') {
+      match.push({ isArchived: true });
     }
 
     const lookup = {


### PR DESCRIPTION
## Summary

Add backend support for archiving/unarchiving jobs so completed items can be hidden from the Lab Monitor and Dashboard.

## Changes

- **Job model** (`job.model.ts`): Added `isArchived`, `archivedAt`, `archivedBy`, and `archivedFromState` fields with compound index
- **Job service** (`job.service.ts`): Added `archiveJob()` and `unarchiveJob()` methods; archive filter in paginated queries; excluded archived jobs from Lab Monitor via `getWorkflowIdsForApprovedJobs()`
- **Job resolver** (`job.resolver.ts`): Added staff-only `archiveJob` and `unarchiveJob` GraphQL mutations
- **Jobs query DTO** (`jobs-query.dto.ts`): Added `archiveFilter` field to `AllJobsInput` (ACTIVE / ARCHIVED / ALL)
- **Job DTO** (`job.dto.ts`): Excluded archive fields from `CreateJobFull` type

## How it works

- `archiveJob(jobId)` sets `isArchived: true` and captures the current state, timestamp, and staff username
- `unarchiveJob(jobId)` restores visibility by clearing archive fields
- Dashboard `allJobs` query respects `archiveFilter` (defaults to `ACTIVE`)
- Lab Monitor excludes archived jobs via `isArchived: { $ne: true }` — no migration needed for existing documents

## Notes

- The frontend (Dashboard archive UI, mutations, filter dropdown) already exists and will work once this backend is deployed
- Uses `{ $ne: true }` so existing documents without `isArchived` are treated as active