### PR TITLE
New sow flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,17 +466,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -3535,17 +3524,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@nestjs/cli/node_modules/cli-width": {
@@ -11006,17 +10984,6 @@
         }
       }
     },
-    "node_modules/inquirer/node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/inquirer/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -18188,14 +18155,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json --forceExit --detectOpenHandles",
-    "initdb": "cd ./scripts; npm install; npm run build; node --env-file=../.env ./bin/dev load all"
+    "initdb": "cd ./scripts; npm install; npm run build; node --env-file=../.env ./bin/dev load all",
+    "migrate:sows": "node --env-file=.env dist/src/sow/migrate-sows.js"
   },
   "dependencies": {
     "@apollo/server": "^5.2.0",

--- a/src/activity/activity-event.model.ts
+++ b/src/activity/activity-event.model.ts
@@ -65,4 +65,3 @@ export class ActivityEvent {
   @Field(() => String, { nullable: true })
   serviceName?: string | null;
 }
-

--- a/src/activity/activity.module.ts
+++ b/src/activity/activity.module.ts
@@ -10,4 +10,3 @@ import { ActivityResolver } from './activity.resolver';
   exports: [ActivityService]
 })
 export class ActivityModule {}
-

--- a/src/activity/activity.resolver.ts
+++ b/src/activity/activity.resolver.ts
@@ -20,4 +20,3 @@ export class ActivityResolver {
     return this.activityService.listEvents({ limit, since });
   }
 }
-

--- a/src/activity/activity.service.spec.ts
+++ b/src/activity/activity.service.spec.ts
@@ -24,10 +24,7 @@ describe('ActivityService', () => {
     };
 
     const moduleRef = await Test.createTestingModule({
-      providers: [
-        ActivityService,
-        { provide: getModelToken(ActivityEventEntity.name), useValue: model }
-      ]
+      providers: [ActivityService, { provide: getModelToken(ActivityEventEntity.name), useValue: model }]
     }).compile();
 
     const svc = moduleRef.get(ActivityService);
@@ -40,4 +37,3 @@ describe('ActivityService', () => {
     expect(events[1].message).toBe('hello');
   });
 });
-

--- a/src/activity/activity.service.ts
+++ b/src/activity/activity.service.ts
@@ -41,4 +41,3 @@ export class ActivityService {
     return this.activityModel.find(filter).sort({ createdAt: -1 }).limit(limit).lean().exec();
   }
 }
-

--- a/src/agent/agent.service.ts
+++ b/src/agent/agent.service.ts
@@ -29,10 +29,7 @@ export interface AgentResult {
 export class AgentService {
   private readonly logger = new Logger(AgentService.name);
 
-  constructor(
-    private readonly dampLabServices: DampLabServices,
-    private readonly configService: ConfigService
-  ) {}
+  constructor(private readonly dampLabServices: DampLabServices, private readonly configService: ConfigService) {}
 
   /**
    * Build a compact catalog of active services for the agent. We deliberately
@@ -52,14 +49,10 @@ export class AgentService {
               name: String(p.name ?? p.id ?? ''),
               type: String(p.type ?? 'string'),
               required: !!p.required,
-              options: Array.isArray(p.options)
-                ? p.options.map((o: any) => (o && o.name ? String(o.name) : String(o))).filter(Boolean)
-                : undefined
+              options: Array.isArray(p.options) ? p.options.map((o: any) => (o && o.name ? String(o.name) : String(o))).filter(Boolean) : undefined
             }))
         : [];
-      const allowedConnections = Array.isArray(s.allowedConnections)
-        ? s.allowedConnections.map((c: any) => String(c?.id ?? c?._id ?? c)).filter(Boolean)
-        : [];
+      const allowedConnections = Array.isArray(s.allowedConnections) ? s.allowedConnections.map((c: any) => String(c?.id ?? c?._id ?? c)).filter(Boolean) : [];
       return {
         id: String(s.id ?? s._id),
         name: String(s.name ?? ''),
@@ -78,16 +71,8 @@ export class AgentService {
    *  - 'canvas'      → workflow builder, catalog injected
    *  - 'lab-status'  → reads Mongo directly via n8n, no catalog
    */
-  async runAgent(
-    agentKey: 'canvas' | 'lab-status',
-    message: string,
-    history: ChatHistoryEntry[],
-    csv?: { filename?: string; content: string } | null
-  ): Promise<AgentResult> {
-    const webhookUrl =
-      agentKey === 'lab-status'
-        ? this.configService.get<string>('agent.labStatusWebhookUrl')
-        : this.configService.get<string>('agent.webhookUrl');
+  async runAgent(agentKey: 'canvas' | 'lab-status', message: string, history: ChatHistoryEntry[], csv?: { filename?: string; content: string } | null): Promise<AgentResult> {
+    const webhookUrl = agentKey === 'lab-status' ? this.configService.get<string>('agent.labStatusWebhookUrl') : this.configService.get<string>('agent.webhookUrl');
     if (!webhookUrl) {
       throw new ServiceUnavailableException(`Agent "${agentKey}" is not configured (missing webhook URL).`);
     }
@@ -129,9 +114,7 @@ export class AgentService {
 
   private normalize(data: Partial<AgentResult> | null): AgentResult {
     const type = data?.type === 'workflow' ? 'workflow' : 'question';
-    const message = String(
-      data?.message || (type === 'question' ? 'Could you tell me more about what you want to do?' : 'Here is a suggested workflow.')
-    );
+    const message = String(data?.message || (type === 'question' ? 'Could you tell me more about what you want to do?' : 'Here is a suggested workflow.'));
     const wf = data?.workflow && typeof data.workflow === 'object' ? data.workflow : { nodes: [], edges: [] };
     return {
       type,

--- a/src/api-key/api-key.resolver.ts
+++ b/src/api-key/api-key.resolver.ts
@@ -22,11 +22,7 @@ export class ApiKeyResolver {
   }
 
   @Mutation(() => CreateApiKeyResult, { description: 'Create a read-only API key. The raw secret is returned once and cannot be retrieved again.' })
-  async createApiKey(
-    @Args('name') name: string,
-    @Args('expiresAt', { type: () => Date, nullable: true }) expiresAt: Date | null,
-    @CurrentUser() user: User
-  ): Promise<CreateApiKeyResult> {
+  async createApiKey(@Args('name') name: string, @Args('expiresAt', { type: () => Date, nullable: true }) expiresAt: Date | null, @CurrentUser() user: User): Promise<CreateApiKeyResult> {
     const createdBy = user?.preferred_username || user?.email || 'staff';
     return this.apiKeyService.create(name, createdBy, expiresAt);
   }

--- a/src/api-key/api-key.service.ts
+++ b/src/api-key/api-key.service.ts
@@ -47,7 +47,10 @@ export class ApiKeyService {
     if (doc.revoked) return null;
     if (doc.expiresAt && new Date(doc.expiresAt).getTime() < Date.now()) return null;
     // fire-and-forget last-used stamp
-    this.model.updateOne({ _id: doc._id }, { $set: { lastUsedAt: new Date() } }).exec().catch(() => undefined);
+    this.model
+      .updateOne({ _id: doc._id }, { $set: { lastUsedAt: new Date() } })
+      .exec()
+      .catch(() => undefined);
     return doc;
   }
 }

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -11,12 +11,7 @@ import { ApiKeyService } from '../api-key/api-key.service';
 
 @Injectable()
 export class AuthRolesGuard implements CanActivate {
-  constructor(
-    private configService: ConfigService,
-    private jwtService: JwtService,
-    private reflector: Reflector,
-    private apiKeyService: ApiKeyService
-  ) {}
+  constructor(private configService: ConfigService, private jwtService: JwtService, private reflector: Reflector, private apiKeyService: ApiKeyService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     let request;

--- a/src/auth/user.interface.ts
+++ b/src/auth/user.interface.ts
@@ -7,4 +7,12 @@ export interface User {
     roles: string[];
   };
   groups?: string[];
+  /**
+   * Set by AuthRolesGuard when the caller authenticated with an x-api-key rather
+   * than a Keycloak token. Such callers have no roles and no owning identity, so
+   * per-record ownership checks must treat them explicitly. Reads only — the
+   * guard rejects mutations from API keys before they reach a resolver.
+   */
+  apiKey?: boolean;
+  readOnly?: boolean;
 }

--- a/src/availability/availability.service.ts
+++ b/src/availability/availability.service.ts
@@ -46,21 +46,12 @@ const overlaps = (aS: Date, aE: Date, bS: Date, bE: Date): boolean => aS < bE &&
  */
 @Injectable()
 export class AvailabilityService {
-  constructor(
-    @InjectModel(WorkflowNode.name) private readonly nodeModel: Model<WorkflowNodeDocument>,
-    @InjectModel(Booking.name) private readonly bookingModel: Model<BookingDocument>
-  ) {}
+  constructor(@InjectModel(WorkflowNode.name) private readonly nodeModel: Model<WorkflowNodeDocument>, @InjectModel(Booking.name) private readonly bookingModel: Model<BookingDocument>) {}
 
   /** Effective [start,end] window an operation's inventory hold occupies. */
   private nodeWindow(n: any): [Date, Date] {
-    const s = n.inventoryReservationStart
-      ? new Date(n.inventoryReservationStart)
-      : n.startedAt
-        ? new Date(n.startedAt)
-        : new Date();
-    const e = n.inventoryReservationEnd
-      ? new Date(n.inventoryReservationEnd)
-      : new Date(s.getTime() + (n.estimatedMinutes || DEFAULT_HOLD_MIN) * 60000);
+    const s = n.inventoryReservationStart ? new Date(n.inventoryReservationStart) : n.startedAt ? new Date(n.startedAt) : new Date();
+    const e = n.inventoryReservationEnd ? new Date(n.inventoryReservationEnd) : new Date(s.getTime() + (n.estimatedMinutes || DEFAULT_HOLD_MIN) * 60000);
     return [s, e];
   }
 
@@ -74,11 +65,7 @@ export class AvailabilityService {
     // --- Operation holds ---
     const nodeFilter: any = { usedInventory: ids.length ? { $in: oids } : { $exists: true, $ne: [] } };
     if (q.excludeNodeId) nodeFilter._id = { $ne: q.excludeNodeId };
-    const nodes = await this.nodeModel
-      .find(nodeFilter)
-      .select('_id label usedInventory state startedAt estimatedMinutes inventoryReservationStart inventoryReservationEnd')
-      .lean()
-      .exec();
+    const nodes = await this.nodeModel.find(nodeFilter).select('_id label usedInventory state startedAt estimatedMinutes inventoryReservationStart inventoryReservationEnd').lean().exec();
     for (const n of nodes as any[]) {
       const hasWindow = !!(n.inventoryReservationStart || n.inventoryReservationEnd);
       // A node "holds" inventory if it's IN_PROGRESS, or has an explicit (possibly future) reservation window.
@@ -100,11 +87,7 @@ export class AvailabilityService {
     };
     if (ids.length) bookingFilter.inventoryItem = { $in: oids };
     if (q.excludeBookingId) bookingFilter._id = { $ne: q.excludeBookingId };
-    const bookings = await this.bookingModel
-      .find(bookingFilter)
-      .select('_id inventoryItem inventoryName startTime endTime ownerName ownerEmail')
-      .lean()
-      .exec();
+    const bookings = await this.bookingModel.find(bookingFilter).select('_id inventoryItem inventoryName startTime endTime ownerName ownerEmail').lean().exec();
     for (const b of bookings as any[]) {
       conflicts.push({
         itemId: String(b.inventoryItem),

--- a/src/booking/booking.service.ts
+++ b/src/booking/booking.service.ts
@@ -25,11 +25,7 @@ const round2 = (n: number): number => Math.round(n * 100) / 100;
 
 @Injectable()
 export class BookingService {
-  constructor(
-    @InjectModel(Booking.name) private readonly model: Model<BookingDocument>,
-    private readonly inventoryService: InventoryService,
-    private readonly availability: AvailabilityService
-  ) {}
+  constructor(@InjectModel(Booking.name) private readonly model: Model<BookingDocument>, private readonly inventoryService: InventoryService, private readonly availability: AvailabilityService) {}
 
   /** Resolve the $/hour or $/unit rate for a customer category from a Pricing object. */
   private resolveRate(pricing: any, category?: string): number | undefined {
@@ -135,17 +131,12 @@ export class BookingService {
     };
 
     if (b.kind === BookingKind.TIMED) {
-      const hours =
-        actualHours != null
-          ? actualHours
-          : b.startTime && b.endTime
-            ? (new Date(b.endTime).getTime() - new Date(b.startTime).getTime()) / 3_600_000
-            : 0;
+      const hours = actualHours != null ? actualHours : b.startTime && b.endTime ? (new Date(b.endTime).getTime() - new Date(b.startTime).getTime()) / 3_600_000 : 0;
       if (hours < 0) throw new BadRequestException('Hours cannot be negative.');
       update.actualHours = round2(hours);
       update.cost = rate != null ? round2(hours * rate) : b.cost;
     } else {
-      const qty = actualQuantity != null ? actualQuantity : (b.quantity ?? 0);
+      const qty = actualQuantity != null ? actualQuantity : b.quantity ?? 0;
       if (qty < 0) throw new BadRequestException('Quantity cannot be negative.');
       update.actualQuantity = qty;
       update.cost = rate != null ? round2(qty * rate) : b.cost;

--- a/src/bug-report/bug-report.dto.ts
+++ b/src/bug-report/bug-report.dto.ts
@@ -1,5 +1,5 @@
 import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
-import { BugAttachment, BugReport, BugSeverity } from './bug-report.model';
+import { BugAttachment, BugSeverity } from './bug-report.model';
 
 @InputType({ description: 'Input for creating a new bug report' })
 export class CreateBugReportInput {

--- a/src/bug-report/bug-report.resolver.ts
+++ b/src/bug-report/bug-report.resolver.ts
@@ -14,11 +14,7 @@ import { BugTriageNotifier } from './bug-triage-notifier.service';
 export class BugReportResolver {
   private readonly logger = new Logger(BugReportResolver.name);
 
-  constructor(
-    private readonly bugReportService: BugReportService,
-    private readonly bugReportAttachmentsService: BugReportAttachmentsService,
-    private readonly triageNotifier: BugTriageNotifier
-  ) {}
+  constructor(private readonly bugReportService: BugReportService, private readonly bugReportAttachmentsService: BugReportAttachmentsService, private readonly triageNotifier: BugTriageNotifier) {}
 
   @Query(() => BugReportsResult, {
     description: 'List all bug reports, optionally filtered by search text and reporter.'

--- a/src/clickup/clickup.resolver.ts
+++ b/src/clickup/clickup.resolver.ts
@@ -57,11 +57,7 @@ export class ClickUpResolver {
   }
 
   @Mutation(() => BacklogComment, { description: 'Add a comment to a backlog card, attributed to the signed-in user.' })
-  async addBacklogComment(
-    @Args('cardId', { type: () => ID }) cardId: string,
-    @Args('body') body: string,
-    @CurrentUser() user: User
-  ): Promise<BacklogComment> {
+  async addBacklogComment(@Args('cardId', { type: () => ID }) cardId: string, @Args('body') body: string, @CurrentUser() user: User): Promise<BacklogComment> {
     // Attribution comes from the verified token, never from client input —
     // otherwise anyone could post as anyone else. Prefer the `name` claim so the
     // thread reads with real names, matching how bug reports capture reporters.

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -22,9 +22,7 @@ export class InventoryService {
     if (!Array.isArray(doc.placements) || doc.placements.length === 0) {
       doc.placements = doc.stationId ? [{ stationId: String(doc.stationId), quantity: 1 }] : [];
     } else {
-      doc.placements = doc.placements
-        .filter((p: any) => p?.stationId)
-        .map((p: any) => ({ stationId: String(p.stationId), quantity: Math.max(1, Math.trunc(Number(p.quantity) || 1)) }));
+      doc.placements = doc.placements.filter((p: any) => p?.stationId).map((p: any) => ({ stationId: String(p.stationId), quantity: Math.max(1, Math.trunc(Number(p.quantity) || 1)) }));
     }
     return item;
   }
@@ -60,7 +58,10 @@ export class InventoryService {
   /** Active-only — for catalog pickers (service editor, lab monitor). */
   async findAllActive(): Promise<InventoryItem[]> {
     return this.normalizeAll(
-      await this.inventoryModel.find({ $or: [{ isDeleted: false }, { isDeleted: { $exists: false } }] }).sort({ name: 1 }).exec()
+      await this.inventoryModel
+        .find({ $or: [{ isDeleted: false }, { isDeleted: { $exists: false } }] })
+        .sort({ name: 1 })
+        .exec()
     );
   }
 

--- a/src/invoice/dto/create-invoice.input.ts
+++ b/src/invoice/dto/create-invoice.input.ts
@@ -10,4 +10,3 @@ export class CreateInvoiceInput {
   })
   serviceIds: string[];
 }
-

--- a/src/invoice/invoice.module.ts
+++ b/src/invoice/invoice.module.ts
@@ -12,4 +12,3 @@ import { SOWModule } from '../sow/sow.module';
   exports: [InvoiceService]
 })
 export class InvoiceModule {}
-

--- a/src/invoice/invoice.resolver.ts
+++ b/src/invoice/invoice.resolver.ts
@@ -40,4 +40,3 @@ export class InvoiceResolver {
     return this.jobService.findById((invoice as any).jobId);
   }
 }
-

--- a/src/invoice/invoice.service.ts
+++ b/src/invoice/invoice.service.ts
@@ -19,11 +19,7 @@ function round2(n: number): number {
 
 @Injectable()
 export class InvoiceService {
-  constructor(
-    @InjectModel(Invoice.name) private readonly invoiceModel: Model<InvoiceDocument>,
-    private readonly jobService: JobService,
-    private readonly sowService: SOWService
-  ) {}
+  constructor(@InjectModel(Invoice.name) private readonly invoiceModel: Model<InvoiceDocument>, private readonly jobService: JobService, private readonly sowService: SOWService) {}
 
   async findByJobId(jobId: string): Promise<Invoice[]> {
     return this.invoiceModel.find({ jobId }).sort({ createdAt: -1 }).exec();
@@ -136,4 +132,3 @@ export class InvoiceService {
     return invoice;
   }
 }
-

--- a/src/job-version/job-version-fields.resolver.ts
+++ b/src/job-version/job-version-fields.resolver.ts
@@ -1,0 +1,13 @@
+import { Resolver, ResolveField, Parent } from '@nestjs/graphql';
+import { JobVersion } from './job-version.model';
+import { JobVersionService } from './job-version.service';
+
+@Resolver(() => JobVersion)
+export class JobVersionFieldsResolver {
+  @ResolveField(() => String, {
+    description: 'Human-facing label: "1.2" for encoded numbers, "3" for pre-scheme integers.'
+  })
+  displayVersion(@Parent() version: JobVersion): string {
+    return JobVersionService.displayVersionLabel(version.versionNumber);
+  }
+}

--- a/src/job-version/job-version.dto.ts
+++ b/src/job-version/job-version.dto.ts
@@ -77,8 +77,13 @@ export class SaveJobWorkflowsInput {
   @Field(() => ID)
   jobId: string;
 
-  @Field({ nullable: true, description: 'Optional note describing what changed' })
-  note?: string;
+  /**
+   * Required on the way in, but `JobVersion.note` stays nullable on the way out:
+   * versions written before this was enforced, and the v1 backfill synthesised
+   * for pre-versioning jobs, both legitimately have no author-written note.
+   */
+  @Field({ description: 'Note describing what changed. Required — the history is unreadable without it.' })
+  note: string;
 
   @Field(() => [SaveWorkflowInput], { description: 'The complete graph. Anything absent is deleted.' })
   workflows: SaveWorkflowInput[];

--- a/src/job-version/job-version.dto.ts
+++ b/src/job-version/job-version.dto.ts
@@ -1,0 +1,85 @@
+import { Field, ID, InputType, Float } from '@nestjs/graphql';
+import JSON from 'graphql-type-json';
+
+/**
+ * Input for `saveJobWorkflows`.
+ *
+ * Deliberately *not* reusing AddWorkflowInput/AddNodeInput. Those run through
+ * AddNodeInputPipe, which prices a node from the *requesting user's* Keycloak
+ * category — correct at checkout, wrong here, where a technician editing a
+ * customer's job must price at the customer's category. Repricing therefore
+ * happens in JobVersionService against `job.customerCategory`.
+ *
+ * Every field a caller may write is named explicitly. Nothing is spread onto a
+ * live document, so UI-only flags (ghost, locked, diffKind) cannot persist even
+ * if the client sends them.
+ */
+
+@InputType({ description: 'Canvas coordinates of a node' })
+export class SaveNodePositionInput {
+  @Field(() => Float)
+  x: number;
+
+  @Field(() => Float)
+  y: number;
+}
+
+@InputType({ description: 'One node in a saved workflow graph' })
+export class SaveNodeInput {
+  @Field(() => ID, { description: 'React Flow client-side node id. Stable across edits; new nodes bring a new one.' })
+  id: string;
+
+  @Field({ description: 'Human readable name of the service' })
+  label: string;
+
+  @Field(() => ID, { description: 'The DampLabService this node represents' })
+  serviceId: string;
+
+  @Field(() => JSON, { nullable: true, description: 'Parameter values; accepted as [{ id, value }] or an object keyed by param id' })
+  formData?: any;
+
+  @Field({ nullable: true, defaultValue: '' })
+  additionalInstructions?: string;
+
+  @Field(() => SaveNodePositionInput, { nullable: true, description: 'Canvas position, persisted into reactNode so the graph reopens where the author left it' })
+  position?: SaveNodePositionInput;
+}
+
+@InputType({ description: 'One edge in a saved workflow graph' })
+export class SaveEdgeInput {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID, { description: 'Client-side id of the source node' })
+  source: string;
+
+  @Field(() => ID, { description: 'Client-side id of the target node' })
+  target: string;
+}
+
+@InputType({ description: 'One disconnected tree on the canvas' })
+export class SaveWorkflowInput {
+  @Field(() => ID, { nullable: true, description: 'Existing Workflow to reconcile against. Omit for a tree created by this edit.' })
+  workflowId?: string;
+
+  @Field({ nullable: true, description: 'Workflow name; the existing name is kept when omitted' })
+  name?: string;
+
+  @Field(() => [SaveNodeInput])
+  nodes: SaveNodeInput[];
+
+  @Field(() => [SaveEdgeInput])
+  edges: SaveEdgeInput[];
+}
+
+@InputType({ description: "Replace a job's workflow graph and record the result as a new version" })
+export class SaveJobWorkflowsInput {
+  @Field(() => ID)
+  jobId: string;
+
+  @Field({ nullable: true, description: 'Optional note describing what changed' })
+  note?: string;
+
+  @Field(() => [SaveWorkflowInput], { description: 'The complete graph. Anything absent is deleted.' })
+  workflows: SaveWorkflowInput[];
+}

--- a/src/job-version/job-version.model.ts
+++ b/src/job-version/job-version.model.ts
@@ -161,8 +161,7 @@ export class JobVersion {
 
   @Prop({ required: true, default: true })
   @Field(() => Boolean, {
-    description:
-      'False for unpublished staff drafts. Missing on legacy rows; treat as true so customers do not lose history.'
+    description: 'False for unpublished staff drafts. Missing on legacy rows; treat as true so customers do not lose history.'
   })
   visibleToCustomer: boolean;
 

--- a/src/job-version/job-version.model.ts
+++ b/src/job-version/job-version.model.ts
@@ -3,6 +3,7 @@ import { Document } from 'mongoose';
 import mongoose from 'mongoose';
 import { Field, ObjectType, ID, Int, Float, registerEnumType } from '@nestjs/graphql';
 import JSON from 'graphql-type-json';
+import { JobState } from '../job/job.model';
 
 /**
  * A job version is an immutable snapshot of a job's workflow graph. Every save
@@ -139,8 +140,31 @@ export class JobVersion {
   @Field(() => [JobVersionWorkflow], { description: 'The whole graph, one entry per disconnected tree' })
   workflows: JobVersionWorkflow[];
 
+  /**
+   * Nullable by necessity, not by preference: versions written before this field
+   * existed have none, and neither does the v1 backfilled for a job submitted
+   * before versioning. The history UI shows the author chip alone in that case.
+   */
   @Prop({ required: false })
-  @Field({ nullable: true, description: 'Optional note describing what changed' })
+  @Field(() => JobState, { nullable: true, description: "The job's state when this version was written. Absent on versions predating the field." })
+  jobState?: JobState;
+
+  /**
+   * True for a version that records a state change rather than a graph edit. Its
+   * workflows are a verbatim copy of its predecessor's, so it diffs empty by
+   * construction — and must be skipped when choosing what to compare against, or
+   * it would silently swallow the edit it followed.
+   */
+  @Prop({ default: false })
+  @Field(() => Boolean, { nullable: true, defaultValue: false, description: 'True when this version records a state change rather than an edit to the graph.' })
+  isEvent?: boolean;
+
+  /**
+   * Optional on the way out — see jobState. `SaveJobWorkflowsInput` requires one
+   * on the way in; the gap is the backfilled v1 and the canned event versions.
+   */
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Note describing what changed' })
   note?: string;
 
   @Prop({ required: true, default: '' })

--- a/src/job-version/job-version.model.ts
+++ b/src/job-version/job-version.model.ts
@@ -1,0 +1,163 @@
+import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+import mongoose from 'mongoose';
+import { Field, ObjectType, ID, Int, Float, registerEnumType } from '@nestjs/graphql';
+import JSON from 'graphql-type-json';
+
+/**
+ * A job version is an immutable snapshot of a job's workflow graph. Every save
+ * from the workflow editor inserts one; nothing is ever updated in place.
+ *
+ * Deliberately a *denormalized* snapshot rather than a clone of the live
+ * Workflow/WorkflowNode documents. A WorkflowNode is not pure content — it
+ * carries operational state (state, assigneeId, startedAt, completedSteps,
+ * usedInventory, inventory reservations) that belongs to the lab, not to the
+ * design. Cloning per version would fork bench progress and duplicate inventory
+ * holds across versions. So the live documents stay the single source of
+ * operational truth, and these snapshots exist purely to be diffed.
+ */
+
+export enum JobVersionAuthorRole {
+  /** Written by the customer who owns the job. */
+  CUSTOMER = 'CUSTOMER',
+  /** Written by DAMP Lab staff. */
+  STAFF = 'STAFF'
+}
+registerEnumType(JobVersionAuthorRole, { name: 'JobVersionAuthorRole' });
+
+@Schema({ _id: false })
+@ObjectType({ description: 'Canvas coordinates of a node at the time this version was written' })
+export class JobVersionPosition {
+  @Prop({ required: true })
+  @Field(() => Float)
+  x: number;
+
+  @Prop({ required: true })
+  @Field(() => Float)
+  y: number;
+}
+
+@Schema({ _id: false })
+@ObjectType({ description: 'One workflow node as frozen into this version' })
+export class JobVersionNode {
+  @Prop({ required: true })
+  @Field(() => ID, {
+    description:
+      'The React Flow client-side node id, carried verbatim from submission through every edit. Diffing is keyed entirely on this — if it were ever regenerated, every node would read as deleted-and-re-added.'
+  })
+  id: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '' })
+  label: string;
+
+  @Prop({ required: false })
+  @Field(() => ID, { nullable: true, description: 'DampLabService this node ran' })
+  serviceId?: string;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Service name at the time of the snapshot, so the diff can label a node without a catalogue lookup' })
+  serviceName?: string;
+
+  @Prop({ type: mongoose.Schema.Types.Mixed, default: [] })
+  @Field(() => JSON, { description: 'Parameter values, canonical array shape: [{ id, value }]' })
+  formData: any;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '' })
+  additionalInstructions: string;
+
+  @Prop({ required: false })
+  @Field(() => Float, { nullable: true, description: 'Node price as computed when this version was saved' })
+  price?: number;
+
+  @Prop({ type: mongoose.Schema.Types.Mixed, required: false })
+  @Field(() => JobVersionPosition, { nullable: true, description: 'Canvas position; absent on legacy jobs submitted before positions were read back' })
+  position?: JobVersionPosition;
+}
+
+@Schema({ _id: false })
+@ObjectType({ description: 'One workflow edge as frozen into this version' })
+export class JobVersionEdge {
+  @Prop({ required: true })
+  @Field(() => ID)
+  id: string;
+
+  @Prop({ required: true })
+  @Field(() => ID, { description: 'Client-side id of the source node (matches JobVersionNode.id)' })
+  source: string;
+
+  @Prop({ required: true })
+  @Field(() => ID, { description: 'Client-side id of the target node (matches JobVersionNode.id)' })
+  target: string;
+}
+
+@Schema({ _id: false })
+@ObjectType({ description: 'One workflow (a connected tree on the canvas) as frozen into this version' })
+export class JobVersionWorkflow {
+  @Prop({ required: false })
+  @Field(() => ID, { nullable: true, description: 'Live Workflow this snapshot came from; null for a tree first created by this edit' })
+  workflowId?: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '' })
+  name: string;
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [JobVersionNode])
+  nodes: JobVersionNode[];
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [JobVersionEdge])
+  edges: JobVersionEdge[];
+}
+
+@Schema({ collection: 'job_versions', timestamps: true })
+@ObjectType({ description: "Immutable snapshot of a job's workflow graph" })
+export class JobVersion {
+  @Field(() => ID, { name: 'id' })
+  _id: string;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Job', required: true })
+  job: mongoose.Types.ObjectId;
+
+  @Prop({ required: true })
+  @Field(() => ID, { description: 'Parent job id (string mirror, for querying)' })
+  jobId: string;
+
+  @Prop({ required: true })
+  @Field(() => Int, { description: 'Sortable, unique within a job. Starts at 1 (the original submission).' })
+  versionNumber: number;
+
+  @Prop({ required: true })
+  @Field(() => JobVersionAuthorRole, {
+    description: "Which side of the conversation wrote this version. The diff baseline is derived from it: baseline(N) is the newest version below N whose authorRole differs from N's."
+  })
+  authorRole: JobVersionAuthorRole;
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [JobVersionWorkflow], { description: 'The whole graph, one entry per disconnected tree' })
+  workflows: JobVersionWorkflow[];
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Optional note describing what changed' })
+  note?: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '', description: 'Keycloak sub of the author' })
+  createdBy: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '', description: 'Display name of the author, resolved at write time' })
+  createdByName: string;
+
+  @Prop({ required: true, default: () => new Date() })
+  @Field()
+  createdAt: Date;
+}
+
+export type JobVersionDocument = JobVersion & Document;
+export const JobVersionSchema = SchemaFactory.createForClass(JobVersion);
+
+// One version number per job; also the index that serves history listing.
+JobVersionSchema.index({ jobId: 1, versionNumber: -1 }, { unique: true });

--- a/src/job-version/job-version.model.ts
+++ b/src/job-version/job-version.model.ts
@@ -159,6 +159,13 @@ export class JobVersion {
   @Field(() => Boolean, { nullable: true, defaultValue: false, description: 'True when this version records a state change rather than an edit to the graph.' })
   isEvent?: boolean;
 
+  @Prop({ required: true, default: true })
+  @Field(() => Boolean, {
+    description:
+      'False for unpublished staff drafts. Missing on legacy rows; treat as true so customers do not lose history.'
+  })
+  visibleToCustomer: boolean;
+
   /**
    * Optional on the way out — see jobState. `SaveJobWorkflowsInput` requires one
    * on the way in; the gap is the backfilled v1 and the canned event versions.

--- a/src/job-version/job-version.module.ts
+++ b/src/job-version/job-version.module.ts
@@ -7,6 +7,7 @@ import { Workflow, WorkflowSchema } from '../workflow/models/workflow.model';
 import { WorkflowNode, WorkflowNodeSchema } from '../workflow/models/node.model';
 import { WorkflowEdge, WorkflowEdgeSchema } from '../workflow/models/edge.model';
 import { DampLabServicesModule } from '../services/damplab-services.module';
+import { JobVersionFieldsResolver } from './job-version-fields.resolver';
 
 /**
  * Versioning owns its own model handles rather than routing through
@@ -27,7 +28,7 @@ import { DampLabServicesModule } from '../services/damplab-services.module';
     ]),
     DampLabServicesModule
   ],
-  providers: [JobVersionService],
+  providers: [JobVersionService, JobVersionFieldsResolver],
   exports: [JobVersionService]
 })
 export class JobVersionModule {}

--- a/src/job-version/job-version.module.ts
+++ b/src/job-version/job-version.module.ts
@@ -1,0 +1,33 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { JobVersion, JobVersionSchema } from './job-version.model';
+import { JobVersionService } from './job-version.service';
+import { Job, JobSchema } from '../job/job.model';
+import { Workflow, WorkflowSchema } from '../workflow/models/workflow.model';
+import { WorkflowNode, WorkflowNodeSchema } from '../workflow/models/node.model';
+import { WorkflowEdge, WorkflowEdgeSchema } from '../workflow/models/edge.model';
+import { DampLabServicesModule } from '../services/damplab-services.module';
+
+/**
+ * Versioning owns its own model handles rather than routing through
+ * WorkflowService/WorkflowNodeService. Reconciling an edited graph is a single
+ * operation that has to interleave node updates, edge replacement and workflow
+ * membership; splitting it across three services would scatter it without
+ * making any part reusable. The collection-owning services stay in charge of
+ * everything else.
+ */
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: JobVersion.name, schema: JobVersionSchema },
+      { name: Job.name, schema: JobSchema },
+      { name: Workflow.name, schema: WorkflowSchema },
+      { name: WorkflowNode.name, schema: WorkflowNodeSchema },
+      { name: WorkflowEdge.name, schema: WorkflowEdgeSchema }
+    ]),
+    DampLabServicesModule
+  ],
+  providers: [JobVersionService],
+  exports: [JobVersionService]
+})
+export class JobVersionModule {}

--- a/src/job-version/job-version.service.spec.ts
+++ b/src/job-version/job-version.service.spec.ts
@@ -12,6 +12,90 @@ import { JobState } from '../job/job.model';
  * told about.
  */
 
+// -------------------------------------------------------------- version numbers
+
+describe('version numbers', () => {
+  it('encodes major.minor as major*1000 + minor', () => {
+    expect(JobVersionService.encodeVersionNumber(0, 1)).toBe(1);
+    expect(JobVersionService.encodeVersionNumber(1, 0)).toBe(1000);
+    expect(JobVersionService.encodeVersionNumber(1, 2)).toBe(1002);
+    expect(JobVersionService.encodeVersionNumber(2, 0)).toBe(2000);
+  });
+
+  it('decodes that encoding back', () => {
+    expect(JobVersionService.decodeVersionNumber(1)).toEqual({ major: 0, minor: 1 });
+    expect(JobVersionService.decodeVersionNumber(1002)).toEqual({ major: 1, minor: 2 });
+  });
+
+  it('labels encoded numbers as major.minor and legacy integers as themselves', () => {
+    expect(JobVersionService.displayVersionLabel(1000)).toBe('1.0');
+    expect(JobVersionService.displayVersionLabel(1002)).toBe('1.2');
+    expect(JobVersionService.displayVersionLabel(3)).toBe('3');
+  });
+
+  it('starts a new job at 1.0 when the first row is a send-equivalent (original submission)', () => {
+    expect(JobVersionService.nextVersionNumber(null, true)).toBe(1000);
+  });
+
+  it('bumps minor on the current major', () => {
+    expect(JobVersionService.nextVersionNumber(1000, false)).toBe(1001);
+    expect(JobVersionService.nextVersionNumber(1002, false)).toBe(1003);
+  });
+
+  it('bumps major and resets minor on Request Changes', () => {
+    expect(JobVersionService.nextVersionNumber(1002, true)).toBe(2000);
+  });
+
+  it('keeps legacy integers consecutive, then jumps to 1.0 on the first major bump', () => {
+    expect(JobVersionService.nextVersionNumber(3, false)).toBe(4);
+    expect(JobVersionService.nextVersionNumber(3, true)).toBe(1000);
+  });
+});
+
+describe('customer visibility filter', () => {
+  const row = (over: Record<string, unknown>) => ({
+    versionNumber: 1000,
+    authorRole: JobVersionAuthorRole.STAFF,
+    visibleToCustomer: true,
+    ...over
+  });
+
+  it('keeps published rows and customer-authored rows', () => {
+    const versions = [
+      row({ versionNumber: 1000, authorRole: JobVersionAuthorRole.CUSTOMER, visibleToCustomer: true }),
+      row({ versionNumber: 1001, visibleToCustomer: false }),
+      row({ versionNumber: 1002, authorRole: JobVersionAuthorRole.CUSTOMER, visibleToCustomer: true }),
+      row({ versionNumber: 2000, visibleToCustomer: true, isEvent: true })
+    ];
+    expect(JobVersionService.filterVisibleToCustomer(versions).map((v) => v.versionNumber)).toEqual([1000, 1002, 2000]);
+  });
+
+  it('treats a missing visibleToCustomer as visible so legacy rows are not hidden', () => {
+    const versions = [row({ versionNumber: 1, visibleToCustomer: undefined })];
+    expect(JobVersionService.filterVisibleToCustomer(versions)).toHaveLength(1);
+  });
+
+  it('still shows a customer-authored row if visibleToCustomer were false', () => {
+    const versions = [row({ authorRole: JobVersionAuthorRole.CUSTOMER, visibleToCustomer: false })];
+    expect(JobVersionService.filterVisibleToCustomer(versions)).toHaveLength(1);
+  });
+});
+
+describe('latestContentVersionNumber', () => {
+  it('skips events and returns the newest content versionNumber', () => {
+    const versions = [
+      { versionNumber: 1000, isEvent: false },
+      { versionNumber: 1001, isEvent: false },
+      { versionNumber: 2000, isEvent: true }
+    ];
+    expect(JobVersionService.latestContentVersionNumber(versions)).toBe(1001);
+  });
+
+  it('is null when there are no versions', () => {
+    expect(JobVersionService.latestContentVersionNumber([])).toBeNull();
+  });
+});
+
 // ------------------------------------------------------------------ baseline
 
 describe('baselineFor', () => {
@@ -333,6 +417,56 @@ describe('saveWorkflows — reconciliation', () => {
     expect(nodes[0].reactNode.position).toEqual({ x: 640, y: 128 });
   });
 
+  // Trees are recomputed from connectivity on every save, so nodes migrate
+  // between them constantly. Deciding deletion per tree used to delete a node
+  // that had merely moved, leaving an edge pointing at nothing — which made the
+  // whole job unreadable, because WorkflowEdge.source throws on a missing node.
+  it('keeps both nodes when deleting an edge splits one tree into two', async () => {
+    const { service, nodes, edges } = buildHarness({ nodes: [liveNode(), liveNode({ id: 'b', _id: NODE_B_DB })] });
+
+    // a and b were connected; the edge is gone, so the editor sends two trees —
+    // the original workflow keeps 'a', and 'b' arrives as a brand new tree.
+    await service.saveWorkflows(
+      {
+        jobId: JOB_ID,
+        note: 'removed the connection',
+        workflows: [
+          { workflowId: WF_ID, nodes: [inputNode()], edges: [] },
+          { nodes: [inputNode({ id: 'b' })], edges: [] }
+        ]
+      } as any,
+      author
+    );
+
+    expect(nodes.map((n) => n.id).sort()).toEqual(['a', 'b']);
+    expect(edges).toHaveLength(0);
+  });
+
+  it('keeps every node when adding an edge merges two trees into one', async () => {
+    const { service, nodes, workflows, edges, job } = buildHarness({ nodes: [liveNode(), liveNode({ id: 'b', _id: NODE_B_DB })] });
+    // Start from two separate trees, the second holding 'b'.
+    const SECOND_WF = '000000000000000000000012';
+    workflows[0].nodes = [NODE_A_DB];
+    workflows.push({ _id: SECOND_WF, name: 'Workflow-2', nodes: [NODE_B_DB], edges: [] });
+    job.workflows = [WF_ID, SECOND_WF];
+
+    await service.saveWorkflows(
+      {
+        jobId: JOB_ID,
+        note: 'connected them',
+        workflows: [{ workflowId: WF_ID, nodes: [inputNode(), inputNode({ id: 'b' })], edges: [{ id: 'e1', source: 'a', target: 'b' }] }]
+      } as any,
+      author
+    );
+
+    expect(nodes.map((n) => n.id).sort()).toEqual(['a', 'b']);
+    // The surviving edge must point at nodes that still exist.
+    expect(edges).toHaveLength(1);
+    const present = new Set(nodes.map((n) => String(n._id)));
+    expect(present.has(String(edges[0].source))).toBe(true);
+    expect(present.has(String(edges[0].target))).toBe(true);
+  });
+
   it('rejects a service that is not in the catalogue rather than writing a dangling node', async () => {
     const { service } = buildHarness({ nodes: [liveNode()] });
     await expect(
@@ -393,13 +527,60 @@ describe('saveWorkflows — pricing and versioning', () => {
   });
 });
 
+describe('visibility and major bumps on write', () => {
+  it('hides a staff editor save from the customer', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    expect(versions[0].visibleToCustomer).toBe(false);
+    expect(versions[0].versionNumber).toBe(1);
+  });
+
+  it('shows a customer editor save', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, { ...author, role: JobVersionAuthorRole.CUSTOMER });
+    expect(versions[0].visibleToCustomer).toBe(true);
+  });
+
+  it('bumps major on Request Changes and marks that row visible', async () => {
+    const { service, versions, job } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    await service.appendStateEvent(job, JobState.CHANGES_REQUESTED, author, 'Changes requested');
+    expect(versions.map((v) => v.versionNumber)).toEqual([1, 1000]);
+    expect(versions[1]).toMatchObject({
+      isEvent: true,
+      visibleToCustomer: true,
+      jobState: JobState.CHANGES_REQUESTED
+    });
+  });
+
+  it('does not bump major on resubmit', async () => {
+    const { service, versions, job } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    await service.appendStateEvent(job, JobState.CHANGES_REQUESTED, author, 'Changes requested');
+    await service.appendStateEvent(job, JobState.SUBMITTED, { ...author, role: JobVersionAuthorRole.CUSTOMER }, 'Resubmitted');
+    expect(versions.map((v) => v.versionNumber)).toEqual([1, 1000, 1001]);
+    expect(versions[2]).toMatchObject({ visibleToCustomer: true, jobState: JobState.SUBMITTED, isEvent: true });
+  });
+
+  it('backfills the original submission as 1.0 and visible', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await service.listByJob(JOB_ID);
+    expect(versions[0]).toMatchObject({
+      versionNumber: 1000,
+      visibleToCustomer: true,
+      note: 'Original submission',
+      authorRole: JobVersionAuthorRole.CUSTOMER
+    });
+  });
+});
+
 describe('listByJob', () => {
   it('synthesizes v1 for a job submitted before versioning existed', async () => {
     const { service, versions } = buildHarness({ nodes: [liveNode()] });
     const listed = await service.listByJob(JOB_ID);
 
     expect(listed).toHaveLength(1);
-    expect(versions[0]).toMatchObject({ versionNumber: 1, authorRole: JobVersionAuthorRole.CUSTOMER, note: 'Original submission' });
+    expect(versions[0]).toMatchObject({ versionNumber: 1000, authorRole: JobVersionAuthorRole.CUSTOMER, note: 'Original submission' });
     expect(versions[0].workflows[0].nodes[0].id).toBe('a');
   });
 
@@ -436,8 +617,8 @@ describe('appendStateEvent', () => {
     await service.appendStateEvent(job, JobState.SUBMITTED, stateAuthor, 'Resubmitted');
 
     expect(versions).toHaveLength(2);
-    expect(versions[0]).toMatchObject({ versionNumber: 1, note: 'Original submission' });
-    expect(versions[1]).toMatchObject({ versionNumber: 2, note: 'Resubmitted', jobState: JobState.SUBMITTED, authorRole: JobVersionAuthorRole.CUSTOMER });
+    expect(versions[0]).toMatchObject({ versionNumber: 1000, note: 'Original submission' });
+    expect(versions[1]).toMatchObject({ versionNumber: 1001, note: 'Resubmitted', jobState: JobState.SUBMITTED, authorRole: JobVersionAuthorRole.CUSTOMER });
   });
 
   it('snapshots the graph unchanged, so the entry diffs empty', async () => {

--- a/src/job-version/job-version.service.spec.ts
+++ b/src/job-version/job-version.service.spec.ts
@@ -53,7 +53,7 @@ describe('version numbers', () => {
 });
 
 describe('customer visibility filter', () => {
-  const row = (over: Record<string, unknown>) => ({
+  const row = (over: Record<string, unknown>): Record<string, unknown> & { versionNumber: number; authorRole: JobVersionAuthorRole; visibleToCustomer?: boolean | null } => ({
     versionNumber: 1000,
     authorRole: JobVersionAuthorRole.STAFF,
     visibleToCustomer: true,

--- a/src/job-version/job-version.service.spec.ts
+++ b/src/job-version/job-version.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { JobVersionService } from './job-version.service';
 import { JobVersionAuthorRole } from './job-version.model';
 import { WorkflowNodeState } from '../workflow/models/node.model';
+import { JobState } from '../job/job.model';
 
 /**
  * The baseline rule is pure, so it is exercised directly. Everything else runs
@@ -44,6 +45,15 @@ describe('baselineFor', () => {
 
   it('returns null for a version that is not in the list', () => {
     expect(JobVersionService.baselineFor(flow, 99)).toBeNull();
+  });
+
+  it('never baselines against a state-change event', () => {
+    // An event version copies its predecessor's graph verbatim, so baselining
+    // against one reports "nothing changed" and hides the edit it followed —
+    // e.g. closing a job right after the customer edited it.
+    const ev = (versionNumber: number, authorRole: JobVersionAuthorRole): any => ({ versionNumber, authorRole, isEvent: true });
+    const withEvent = [v(1, CUSTOMER), v(2, STAFF), ev(3, STAFF), v(4, CUSTOMER)];
+    expect(JobVersionService.baselineFor(withEvent, 4)).toBe(2);
   });
 });
 
@@ -194,30 +204,32 @@ const author = { role: JobVersionAuthorRole.STAFF, sub: 'tech-1', name: 'tech@bu
 describe('saveWorkflows — work already in flight', () => {
   it('refuses to delete a node the lab has started', async () => {
     const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
-    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [], edges: [] }] } as any, author)).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [], edges: [] }] } as any, author)).rejects.toBeInstanceOf(BadRequestException);
   });
 
   it('refuses to delete a node that is holding inventory', async () => {
     const { service } = buildHarness({ nodes: [liveNode({ usedInventory: ['inv-1'] })] });
-    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [], edges: [] }] } as any, author)).rejects.toThrow(/holding inventory/);
+    await expect(service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [], edges: [] }] } as any, author)).rejects.toThrow(/holding inventory/);
   });
 
   it('refuses to change the parameters of a node in progress', async () => {
     const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
-    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 999 }] })], edges: [] }] } as any, author)).rejects.toThrow(
-      /parameters changed/
-    );
+    await expect(
+      service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 999 }] })], edges: [] }] } as any, author)
+    ).rejects.toThrow(/parameters changed/);
   });
 
   it('refuses to swap the service of a node in progress', async () => {
     const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
-    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ serviceId: SVC_B })], edges: [] }] } as any, author)).rejects.toThrow(/change service/);
+    await expect(service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode({ serviceId: SVC_B })], edges: [] }] } as any, author)).rejects.toThrow(
+      /change service/
+    );
   });
 
   it('allows an in-progress node through untouched, so the rest of the graph stays editable', async () => {
     const { service, nodes } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
     await service.saveWorkflows(
-      { jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode(), inputNode({ id: 'b', serviceId: SVC_B, label: 'Sequencing', formData: [] })], edges: [] }] } as any,
+      { jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode(), inputNode({ id: 'b', serviceId: SVC_B, label: 'Sequencing', formData: [] })], edges: [] }] } as any,
       author
     );
     expect(nodes).toHaveLength(2);
@@ -239,6 +251,7 @@ describe('saveWorkflows — work already in flight', () => {
       service.saveWorkflows(
         {
           jobId: JOB_ID,
+          note: 'edited',
           workflows: [
             {
               workflowId: WF_ID,
@@ -266,7 +279,7 @@ describe('saveWorkflows — reconciliation', () => {
       nodes: [liveNode({ assigneeId: 'staff-9', assigneeDisplayName: 'Sam', completedSteps: ['step-1', 'step-2'], startedAt: new Date('2026-08-01') })]
     });
 
-    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 42 }] })], edges: [] }] } as any, author);
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 42 }] })], edges: [] }] } as any, author);
 
     const saved = nodes[0];
     expect(saved.formData).toEqual([{ id: 'vol', value: 42 }]);
@@ -284,6 +297,7 @@ describe('saveWorkflows — reconciliation', () => {
     await service.saveWorkflows(
       {
         jobId: JOB_ID,
+        note: 'edited',
         workflows: [{ workflowId: WF_ID, nodes: [{ ...inputNode(), ghost: true, locked: true, diffKind: 'changed', state: WorkflowNodeState.COMPLETE }], edges: [] }]
       } as any,
       author
@@ -299,7 +313,7 @@ describe('saveWorkflows — reconciliation', () => {
   it('creates a node the editor added, queued', async () => {
     const { service, nodes } = buildHarness({ nodes: [liveNode()] });
     await service.saveWorkflows(
-      { jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode(), inputNode({ id: 'new1', serviceId: SVC_B, label: 'Sequencing', formData: [] })], edges: [] }] } as any,
+      { jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode(), inputNode({ id: 'new1', serviceId: SVC_B, label: 'Sequencing', formData: [] })], edges: [] }] } as any,
       author
     );
     const added = nodes.find((n) => n.id === 'new1');
@@ -309,21 +323,21 @@ describe('saveWorkflows — reconciliation', () => {
 
   it('deletes a queued node the editor removed', async () => {
     const { service, nodes } = buildHarness({ nodes: [liveNode(), liveNode({ id: 'b', _id: NODE_B_DB })] });
-    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
     expect(nodes.map((n) => n.id)).toEqual(['a']);
   });
 
   it('stores the position so the graph reopens where its author left it', async () => {
     const { service, nodes } = buildHarness({ nodes: [liveNode()] });
-    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ position: { x: 640, y: 128 } })], edges: [] }] } as any, author);
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode({ position: { x: 640, y: 128 } })], edges: [] }] } as any, author);
     expect(nodes[0].reactNode.position).toEqual({ x: 640, y: 128 });
   });
 
   it('rejects a service that is not in the catalogue rather than writing a dangling node', async () => {
     const { service } = buildHarness({ nodes: [liveNode()] });
-    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ serviceId: 'nope' })], edges: [] }] } as any, author)).rejects.toBeInstanceOf(
-      BadRequestException
-    );
+    await expect(
+      service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode({ serviceId: 'nope' })], edges: [] }] } as any, author)
+    ).rejects.toBeInstanceOf(BadRequestException);
   });
 });
 
@@ -333,7 +347,7 @@ describe('saveWorkflows — pricing and versioning', () => {
     const internalService = { ...SERVICE_A, pricing: { internal: 25, external: 400 } };
     (service as any).dampLabServices.findOneActive = async (): Promise<any> => internalService;
 
-    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
 
     // A technician saved this, but the job belongs to an internal customer.
     expect(nodes[0].price).toBe(25);
@@ -341,7 +355,7 @@ describe('saveWorkflows — pricing and versioning', () => {
 
   it('appends exactly one version per save, numbered in sequence', async () => {
     const { service, versions } = buildHarness({ nodes: [liveNode()] });
-    const input = { jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any;
+    const input = { jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any;
 
     await service.saveWorkflows(input, author);
     await service.saveWorkflows(input, { ...author, role: JobVersionAuthorRole.CUSTOMER });
@@ -358,7 +372,7 @@ describe('saveWorkflows — pricing and versioning', () => {
 
   it('snapshots the saved graph, keyed by the client-side node id', async () => {
     const { service, versions } = buildHarness({ nodes: [liveNode()] });
-    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 7 }] })], edges: [] }] } as any, author);
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 7 }] })], edges: [] }] } as any, author);
     const snapshot = versions[0].workflows[0];
     expect(snapshot.nodes[0].id).toBe('a');
     expect(snapshot.nodes[0].formData).toEqual([{ id: 'vol', value: 7 }]);
@@ -367,6 +381,15 @@ describe('saveWorkflows — pricing and versioning', () => {
   it('rejects an unknown job', async () => {
     const { service } = buildHarness();
     await expect(service.saveWorkflows({ jobId: '0000000000000000000000ff', workflows: [] } as any, author)).rejects.toThrow(/not found/);
+  });
+
+  it('rejects a save whose note is only whitespace', async () => {
+    // The schema stops a missing note; this is the one that would otherwise slip
+    // through typed and still leave the history entry unlabelled.
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await expect(service.saveWorkflows({ jobId: JOB_ID, note: '  ', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author)).rejects.toBeInstanceOf(BadRequestException);
+    // Rejected before anything was written.
+    expect(versions).toHaveLength(0);
   });
 });
 
@@ -391,6 +414,51 @@ describe('listByJob', () => {
     const { service } = buildHarness();
     expect(await service.listByJob('0000000000000000000000ff')).toEqual([]);
   });
+
+  it('leaves the backfilled v1 without a job state, since none was recorded', async () => {
+    // The state chip has nothing to show for it, which is the intended reading —
+    // better than inventing a state the job may not have been in at the time.
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await service.listByJob(JOB_ID);
+    expect(versions[0].jobState).toBeUndefined();
+  });
+});
+
+describe('appendStateEvent', () => {
+  const stateAuthor = { role: JobVersionAuthorRole.CUSTOMER, sub: 'client-1', name: 'jane@bu.edu' };
+
+  it('backfills the original submission before recording the event', async () => {
+    // On a job submitted before versioning existed, writing the event straight in
+    // would take version 1 — and listByJob only backfills when it finds *no*
+    // versions, so the original submission would be lost for good and the
+    // history would open with "Resubmitted" against nothing.
+    const { service, versions, job } = buildHarness({ nodes: [liveNode()] });
+    await service.appendStateEvent(job, JobState.SUBMITTED, stateAuthor, 'Resubmitted');
+
+    expect(versions).toHaveLength(2);
+    expect(versions[0]).toMatchObject({ versionNumber: 1, note: 'Original submission' });
+    expect(versions[1]).toMatchObject({ versionNumber: 2, note: 'Resubmitted', jobState: JobState.SUBMITTED, authorRole: JobVersionAuthorRole.CUSTOMER });
+  });
+
+  it('snapshots the graph unchanged, so the entry diffs empty', async () => {
+    // The point of an event version: it marks that something happened without
+    // claiming the workflow changed.
+    const { service, versions, job } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    await service.appendStateEvent(job, JobState.CHANGES_REQUESTED, stateAuthor, 'Changes requested');
+
+    const [saved, event] = versions;
+    expect(versions).toHaveLength(2);
+    expect(event.workflows).toEqual(saved.workflows);
+    expect(event.note).toBe('Changes requested');
+  });
+
+  it('writes nothing for a job with no workflows to snapshot', async () => {
+    const { service, versions, job } = buildHarness();
+    job.workflows = [];
+    expect(await service.appendStateEvent(job, JobState.CLOSED, stateAuthor, 'Closed')).toBeNull();
+    expect(versions).toHaveLength(0);
+  });
 });
 
 describe('saveWorkflows — catalogue drift against an in-flight node', () => {
@@ -403,6 +471,7 @@ describe('saveWorkflows — catalogue drift against an in-flight node', () => {
       service.saveWorkflows(
         {
           jobId: JOB_ID,
+          note: 'edited',
           workflows: [
             {
               workflowId: WF_ID,
@@ -429,6 +498,7 @@ describe('saveWorkflows — catalogue drift against an in-flight node', () => {
       service.saveWorkflows(
         {
           jobId: JOB_ID,
+          note: 'edited',
           workflows: [
             {
               workflowId: WF_ID,
@@ -457,6 +527,7 @@ describe('saveWorkflows — catalogue drift against an in-flight node', () => {
       service.saveWorkflows(
         {
           jobId: JOB_ID,
+          note: 'edited',
           workflows: [
             {
               workflowId: WF_ID,
@@ -483,6 +554,7 @@ describe('saveWorkflows — catalogue drift against an in-flight node', () => {
       service.saveWorkflows(
         {
           jobId: JOB_ID,
+          note: 'edited',
           workflows: [
             {
               workflowId: WF_ID,
@@ -506,7 +578,7 @@ describe('saveWorkflows — catalogue drift against an in-flight node', () => {
   it('treats a number typed as text as the same value', async () => {
     const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS, formData: [{ id: 'vol', value: 10 }] })] });
     await expect(
-      service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: '10' }] })], edges: [] }] } as any, author)
+      service.saveWorkflows({ jobId: JOB_ID, note: 'edited', workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: '10' }] })], edges: [] }] } as any, author)
     ).resolves.toBeDefined();
   });
 });

--- a/src/job-version/job-version.service.spec.ts
+++ b/src/job-version/job-version.service.spec.ts
@@ -1,0 +1,512 @@
+import { BadRequestException } from '@nestjs/common';
+import { JobVersionService } from './job-version.service';
+import { JobVersionAuthorRole } from './job-version.model';
+import { WorkflowNodeState } from '../workflow/models/node.model';
+
+/**
+ * The baseline rule is pure, so it is exercised directly. Everything else runs
+ * against a small in-memory stand-in for the four collections `saveWorkflows`
+ * touches — enough to pin the two properties that actually matter: that a save
+ * never disturbs live lab state, and that it cannot persist a field it was not
+ * told about.
+ */
+
+// ------------------------------------------------------------------ baseline
+
+describe('baselineFor', () => {
+  const v = (versionNumber: number, authorRole: JobVersionAuthorRole): { versionNumber: number; authorRole: JobVersionAuthorRole } => ({ versionNumber, authorRole });
+  const CUSTOMER = JobVersionAuthorRole.CUSTOMER;
+  const STAFF = JobVersionAuthorRole.STAFF;
+
+  // The flow in the brief: customer submits, technician edits, customer edits back.
+  const flow = [v(1, CUSTOMER), v(2, STAFF), v(3, CUSTOMER)];
+
+  it('compares a technician edit against the customer submission', () => {
+    expect(JobVersionService.baselineFor(flow, 2)).toBe(1);
+  });
+
+  it('compares a customer edit against the version the technician sent', () => {
+    expect(JobVersionService.baselineFor(flow, 3)).toBe(2);
+  });
+
+  it('has no baseline for the original submission', () => {
+    expect(JobVersionService.baselineFor(flow, 1)).toBeNull();
+  });
+
+  it('collapses two consecutive technician saves into one diff from the submission', () => {
+    // Otherwise the customer would only be shown the second of the two edits.
+    expect(JobVersionService.baselineFor([v(1, CUSTOMER), v(2, STAFF), v(3, STAFF)], 3)).toBe(1);
+  });
+
+  it('collapses two consecutive customer saves against what they were sent', () => {
+    expect(JobVersionService.baselineFor([v(1, CUSTOMER), v(2, STAFF), v(3, CUSTOMER), v(4, CUSTOMER)], 4)).toBe(2);
+  });
+
+  it('returns null for a version that is not in the list', () => {
+    expect(JobVersionService.baselineFor(flow, 99)).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------ saveWorkflows
+
+// Real ObjectId strings: the service converts these, so a placeholder like
+// 'job1' would fail inside BSON rather than exercising anything.
+const JOB_ID = '000000000000000000000001';
+const WF_ID = '000000000000000000000011';
+const NODE_A_DB = '00000000000000000000000a';
+const NODE_B_DB = '00000000000000000000000b';
+const SVC_A = '0000000000000000000000aa';
+const SVC_B = '0000000000000000000000bb';
+
+const SERVICE_A = { _id: SVC_A, name: 'Gibson Assembly', price: 100, parameters: [{ id: 'vol', name: 'Volume', type: 'number' }] };
+const SERVICE_B = { _id: SVC_B, name: 'Sequencing', price: 250, parameters: [] };
+
+interface Harness {
+  service: JobVersionService;
+  nodes: any[];
+  edges: any[];
+  workflows: any[];
+  versions: any[];
+  job: any;
+}
+
+/** Minimal mongoose-shaped fakes over plain arrays. */
+function buildHarness(options: { nodes?: any[]; customerCategory?: string } = {}): Harness {
+  const nodes: any[] = options.nodes ?? [];
+  const edges: any[] = [];
+  const versions: any[] = [];
+  const workflows: any[] = [{ _id: WF_ID, name: 'Workflow-1', nodes: nodes.map((n) => n._id), edges: [] }];
+  const job: any = { _id: JOB_ID, sub: 'user-1', workflows: [WF_ID], customerCategory: options.customerCategory };
+
+  let autoId = 0;
+  // Also a valid ObjectId — newly created docs get their ids converted too.
+  const nextId = (): string => String(++autoId).padStart(24, 'f');
+  const exec = <T>(value: T): { exec: () => Promise<T> } => ({ exec: async (): Promise<T> => value });
+
+  const applySet = (target: any, update: any): any => Object.assign(target, update?.$set ?? {});
+
+  const nodeModel: any = {
+    find: (q: any) => exec(nodes.filter((n) => q._id.$in.map(String).includes(String(n._id)))),
+    findById: (id: string) => exec(nodes.find((n) => String(n._id) === String(id)) ?? null),
+    findByIdAndUpdate: (id: string, update: any) => {
+      const node = nodes.find((n) => String(n._id) === String(id));
+      if (node) applySet(node, update);
+      return exec(node ?? null);
+    },
+    create: async (doc: any) => {
+      const created = { _id: nextId(), ...doc };
+      nodes.push(created);
+      return created;
+    },
+    deleteMany: (q: any) => {
+      const ids = q._id.$in.map(String);
+      for (let i = nodes.length - 1; i >= 0; i--) if (ids.includes(String(nodes[i]._id))) nodes.splice(i, 1);
+      return exec(undefined);
+    }
+  };
+
+  const edgeModel: any = {
+    find: (q: any) => exec(edges.filter((e) => q._id.$in.map(String).includes(String(e._id)))),
+    create: async (doc: any) => {
+      const created = { _id: nextId(), ...doc };
+      edges.push(created);
+      return created;
+    },
+    deleteMany: (q: any) => {
+      const ids = q._id.$in.map(String);
+      for (let i = edges.length - 1; i >= 0; i--) if (ids.includes(String(edges[i]._id))) edges.splice(i, 1);
+      return exec(undefined);
+    }
+  };
+
+  const workflowModel: any = {
+    findById: (id: string) => exec(workflows.find((w) => String(w._id) === String(id)) ?? null),
+    findByIdAndUpdate: (id: string, update: any) => {
+      const wf = workflows.find((w) => String(w._id) === String(id));
+      if (wf) applySet(wf, update);
+      return exec(wf ?? null);
+    },
+    findByIdAndDelete: (id: string) => {
+      const i = workflows.findIndex((w) => String(w._id) === String(id));
+      if (i >= 0) workflows.splice(i, 1);
+      return exec(undefined);
+    },
+    create: async (doc: any) => {
+      const created = { _id: nextId(), ...doc };
+      workflows.push(created);
+      return created;
+    }
+  };
+
+  const jobModel: any = {
+    findById: (id: string) => exec(String(id) === JOB_ID ? job : null),
+    findByIdAndUpdate: (_id: string, update: any) => {
+      applySet(job, update);
+      return exec(job);
+    }
+  };
+
+  const versionModel: any = {
+    find: () => ({ sort: () => exec([...versions].sort((a, b) => a.versionNumber - b.versionNumber)) }),
+    findOne: () => ({ sort: () => exec([...versions].sort((a, b) => b.versionNumber - a.versionNumber)[0] ?? null) }),
+    create: async (doc: any) => {
+      versions.push(doc);
+      return doc;
+    }
+  };
+
+  const dampLabServices: any = {
+    findOneActive: async (id: string) => (String(id) === SVC_A ? SERVICE_A : String(id) === SVC_B ? SERVICE_B : null)
+  };
+
+  const service = new JobVersionService(versionModel, jobModel, workflowModel, nodeModel, edgeModel, dampLabServices);
+  return { service, nodes, edges, workflows, versions, job };
+}
+
+const liveNode = (over: Partial<any> = {}): any => ({
+  _id: NODE_A_DB,
+  id: 'a',
+  label: 'Gibson Assembly',
+  service: SVC_A,
+  additionalInstructions: '',
+  formData: [{ id: 'vol', value: 10 }],
+  reactNode: { position: { x: 10, y: 20 } },
+  state: WorkflowNodeState.QUEUED,
+  price: 100,
+  usedInventory: [],
+  assigneeId: undefined,
+  completedSteps: [],
+  ...over
+});
+
+const inputNode = (over: Record<string, any> = {}): any => ({
+  id: 'a',
+  label: 'Gibson Assembly',
+  serviceId: SVC_A,
+  formData: [{ id: 'vol', value: 10 }],
+  additionalInstructions: '',
+  position: { x: 10, y: 20 },
+  ...over
+});
+
+const author = { role: JobVersionAuthorRole.STAFF, sub: 'tech-1', name: 'tech@bu.edu' };
+
+describe('saveWorkflows — work already in flight', () => {
+  it('refuses to delete a node the lab has started', async () => {
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
+    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [], edges: [] }] } as any, author)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('refuses to delete a node that is holding inventory', async () => {
+    const { service } = buildHarness({ nodes: [liveNode({ usedInventory: ['inv-1'] })] });
+    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [], edges: [] }] } as any, author)).rejects.toThrow(/holding inventory/);
+  });
+
+  it('refuses to change the parameters of a node in progress', async () => {
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
+    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 999 }] })], edges: [] }] } as any, author)).rejects.toThrow(
+      /parameters changed/
+    );
+  });
+
+  it('refuses to swap the service of a node in progress', async () => {
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
+    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ serviceId: SVC_B })], edges: [] }] } as any, author)).rejects.toThrow(/change service/);
+  });
+
+  it('allows an in-progress node through untouched, so the rest of the graph stays editable', async () => {
+    const { service, nodes } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS })] });
+    await service.saveWorkflows(
+      { jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode(), inputNode({ id: 'b', serviceId: SVC_B, label: 'Sequencing', formData: [] })], edges: [] }] } as any,
+      author
+    );
+    expect(nodes).toHaveLength(2);
+  });
+
+  it('does not care about parameter ordering when checking an in-flight node', async () => {
+    const { service } = buildHarness({
+      nodes: [
+        liveNode({
+          state: WorkflowNodeState.IN_PROGRESS,
+          formData: [
+            { id: 'vol', value: 10 },
+            { id: 'buf', value: 'TE' }
+          ]
+        })
+      ]
+    });
+    await expect(
+      service.saveWorkflows(
+        {
+          jobId: JOB_ID,
+          workflows: [
+            {
+              workflowId: WF_ID,
+              nodes: [
+                inputNode({
+                  formData: [
+                    { id: 'buf', value: 'TE' },
+                    { id: 'vol', value: 10 }
+                  ]
+                })
+              ],
+              edges: []
+            }
+          ]
+        } as any,
+        author
+      )
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('saveWorkflows — reconciliation', () => {
+  it('preserves operational state on a node whose parameters were edited', async () => {
+    const { service, nodes } = buildHarness({
+      nodes: [liveNode({ assigneeId: 'staff-9', assigneeDisplayName: 'Sam', completedSteps: ['step-1', 'step-2'], startedAt: new Date('2026-08-01') })]
+    });
+
+    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 42 }] })], edges: [] }] } as any, author);
+
+    const saved = nodes[0];
+    expect(saved.formData).toEqual([{ id: 'vol', value: 42 }]);
+    // None of this is the editor's to touch.
+    expect(saved.assigneeId).toBe('staff-9');
+    expect(saved.assigneeDisplayName).toBe('Sam');
+    expect(saved.completedSteps).toEqual(['step-1', 'step-2']);
+    expect(saved.startedAt).toEqual(new Date('2026-08-01'));
+    expect(saved.state).toBe(WorkflowNodeState.QUEUED);
+  });
+
+  it('persists nothing it was not told about, so a UI-only flag can never leak', async () => {
+    const { service, nodes } = buildHarness({ nodes: [liveNode()] });
+
+    await service.saveWorkflows(
+      {
+        jobId: JOB_ID,
+        workflows: [{ workflowId: WF_ID, nodes: [{ ...inputNode(), ghost: true, locked: true, diffKind: 'changed', state: WorkflowNodeState.COMPLETE }], edges: [] }]
+      } as any,
+      author
+    );
+
+    const saved = nodes[0];
+    expect(saved.ghost).toBeUndefined();
+    expect(saved.locked).toBeUndefined();
+    expect(saved.diffKind).toBeUndefined();
+    expect(saved.state).toBe(WorkflowNodeState.QUEUED);
+  });
+
+  it('creates a node the editor added, queued', async () => {
+    const { service, nodes } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows(
+      { jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode(), inputNode({ id: 'new1', serviceId: SVC_B, label: 'Sequencing', formData: [] })], edges: [] }] } as any,
+      author
+    );
+    const added = nodes.find((n) => n.id === 'new1');
+    expect(added).toBeDefined();
+    expect(added.state).toBe(WorkflowNodeState.QUEUED);
+  });
+
+  it('deletes a queued node the editor removed', async () => {
+    const { service, nodes } = buildHarness({ nodes: [liveNode(), liveNode({ id: 'b', _id: NODE_B_DB })] });
+    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    expect(nodes.map((n) => n.id)).toEqual(['a']);
+  });
+
+  it('stores the position so the graph reopens where its author left it', async () => {
+    const { service, nodes } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ position: { x: 640, y: 128 } })], edges: [] }] } as any, author);
+    expect(nodes[0].reactNode.position).toEqual({ x: 640, y: 128 });
+  });
+
+  it('rejects a service that is not in the catalogue rather than writing a dangling node', async () => {
+    const { service } = buildHarness({ nodes: [liveNode()] });
+    await expect(service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ serviceId: 'nope' })], edges: [] }] } as any, author)).rejects.toBeInstanceOf(
+      BadRequestException
+    );
+  });
+});
+
+describe('saveWorkflows — pricing and versioning', () => {
+  it("prices from the job's customer category, not the editing user's", async () => {
+    const { service, nodes } = buildHarness({ nodes: [liveNode()], customerCategory: 'INTERNAL_CUSTOMERS' });
+    const internalService = { ...SERVICE_A, pricing: { internal: 25, external: 400 } };
+    (service as any).dampLabServices.findOneActive = async (): Promise<any> => internalService;
+
+    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+
+    // A technician saved this, but the job belongs to an internal customer.
+    expect(nodes[0].price).toBe(25);
+  });
+
+  it('appends exactly one version per save, numbered in sequence', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    const input = { jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any;
+
+    await service.saveWorkflows(input, author);
+    await service.saveWorkflows(input, { ...author, role: JobVersionAuthorRole.CUSTOMER });
+
+    expect(versions.map((v) => v.versionNumber)).toEqual([1, 2]);
+    expect(versions.map((v) => v.authorRole)).toEqual([JobVersionAuthorRole.STAFF, JobVersionAuthorRole.CUSTOMER]);
+  });
+
+  it('records the author and note on the version', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, note: 'Bumped the volume', workflows: [{ workflowId: WF_ID, nodes: [inputNode()], edges: [] }] } as any, author);
+    expect(versions[0]).toMatchObject({ note: 'Bumped the volume', createdBy: 'tech-1', createdByName: 'tech@bu.edu' });
+  });
+
+  it('snapshots the saved graph, keyed by the client-side node id', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: 7 }] })], edges: [] }] } as any, author);
+    const snapshot = versions[0].workflows[0];
+    expect(snapshot.nodes[0].id).toBe('a');
+    expect(snapshot.nodes[0].formData).toEqual([{ id: 'vol', value: 7 }]);
+  });
+
+  it('rejects an unknown job', async () => {
+    const { service } = buildHarness();
+    await expect(service.saveWorkflows({ jobId: '0000000000000000000000ff', workflows: [] } as any, author)).rejects.toThrow(/not found/);
+  });
+});
+
+describe('listByJob', () => {
+  it('synthesizes v1 for a job submitted before versioning existed', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    const listed = await service.listByJob(JOB_ID);
+
+    expect(listed).toHaveLength(1);
+    expect(versions[0]).toMatchObject({ versionNumber: 1, authorRole: JobVersionAuthorRole.CUSTOMER, note: 'Original submission' });
+    expect(versions[0].workflows[0].nodes[0].id).toBe('a');
+  });
+
+  it('does not synthesize a second time', async () => {
+    const { service, versions } = buildHarness({ nodes: [liveNode()] });
+    await service.listByJob(JOB_ID);
+    await service.listByJob(JOB_ID);
+    expect(versions).toHaveLength(1);
+  });
+
+  it('returns nothing for a job that does not exist', async () => {
+    const { service } = buildHarness();
+    expect(await service.listByJob('0000000000000000000000ff')).toEqual([]);
+  });
+});
+
+describe('saveWorkflows — catalogue drift against an in-flight node', () => {
+  it('does not treat a parameter the catalogue gained as a user edit', async () => {
+    // The editor always sends the *current* catalogue's parameter set, so a
+    // parameter added since submission arrives with an empty value. That is not
+    // something the user changed, and must not block the save.
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS, formData: [{ id: 'vol', value: 10 }] })] });
+    await expect(
+      service.saveWorkflows(
+        {
+          jobId: JOB_ID,
+          workflows: [
+            {
+              workflowId: WF_ID,
+              nodes: [
+                inputNode({
+                  formData: [
+                    { id: 'vol', value: 10 },
+                    { id: 'temp', value: null }
+                  ]
+                })
+              ],
+              edges: []
+            }
+          ]
+        } as any,
+        author
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it('still blocks a real edit to a parameter on an in-flight node', async () => {
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS, formData: [{ id: 'vol', value: 10 }] })] });
+    await expect(
+      service.saveWorkflows(
+        {
+          jobId: JOB_ID,
+          workflows: [
+            {
+              workflowId: WF_ID,
+              nodes: [
+                inputNode({
+                  formData: [
+                    { id: 'vol', value: 10 },
+                    { id: 'temp', value: 37 }
+                  ]
+                })
+              ],
+              edges: []
+            }
+          ]
+        } as any,
+        author
+      )
+    ).rejects.toThrow(/parameters changed/);
+  });
+
+  it('does not treat the universal run-count default as an edit', async () => {
+    // Jobs submitted before the run-count entry existed store no __runCount, but
+    // the editor always sends it as 1. Absent and 1 mean the same thing.
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS, formData: [{ id: 'vol', value: 10 }] })] });
+    await expect(
+      service.saveWorkflows(
+        {
+          jobId: JOB_ID,
+          workflows: [
+            {
+              workflowId: WF_ID,
+              nodes: [
+                inputNode({
+                  formData: [
+                    { id: 'vol', value: 10 },
+                    { id: '__runCount', value: 1 }
+                  ]
+                })
+              ],
+              edges: []
+            }
+          ]
+        } as any,
+        author
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it('still blocks a real run-count change on an in-flight node', async () => {
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS, formData: [{ id: 'vol', value: 10 }] })] });
+    await expect(
+      service.saveWorkflows(
+        {
+          jobId: JOB_ID,
+          workflows: [
+            {
+              workflowId: WF_ID,
+              nodes: [
+                inputNode({
+                  formData: [
+                    { id: 'vol', value: 10 },
+                    { id: '__runCount', value: 4 }
+                  ]
+                })
+              ],
+              edges: []
+            }
+          ]
+        } as any,
+        author
+      )
+    ).rejects.toThrow(/parameters changed/);
+  });
+
+  it('treats a number typed as text as the same value', async () => {
+    const { service } = buildHarness({ nodes: [liveNode({ state: WorkflowNodeState.IN_PROGRESS, formData: [{ id: 'vol', value: 10 }] })] });
+    await expect(
+      service.saveWorkflows({ jobId: JOB_ID, workflows: [{ workflowId: WF_ID, nodes: [inputNode({ formData: [{ id: 'vol', value: '10' }] })], edges: [] }] } as any, author)
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/job-version/job-version.service.ts
+++ b/src/job-version/job-version.service.ts
@@ -109,6 +109,58 @@ export class JobVersionService {
     private readonly dampLabServices: DampLabServices
   ) {}
 
+  // ---------------------------------------------------------- version numbers
+
+  private static readonly MINOR_WIDTH = 1000;
+
+  static encodeVersionNumber(major: number, minor: number): number {
+    return major * JobVersionService.MINOR_WIDTH + minor;
+  }
+
+  static decodeVersionNumber(versionNumber: number): { major: number; minor: number } {
+    return {
+      major: Math.floor(versionNumber / JobVersionService.MINOR_WIDTH),
+      minor: versionNumber % JobVersionService.MINOR_WIDTH
+    };
+  }
+
+  /** Encoded values as "1.2"; pre-scheme integers (< 1000) as "3". */
+  static displayVersionLabel(versionNumber: number): string {
+    if (versionNumber < JobVersionService.MINOR_WIDTH) return String(versionNumber);
+    const { major, minor } = JobVersionService.decodeVersionNumber(versionNumber);
+    return `${major}.${minor}`;
+  }
+
+  /**
+   * Next free versionNumber.
+   *
+   * `highest` is the current max on the job (events included). `bumpMajor` is
+   * true only for Request Changes and for the original submission (the first
+   * row of a new job). Legacy jobs whose highest is still < 1000 stay on
+   * consecutive integers until the first major bump, which becomes 1.0.
+   */
+  static nextVersionNumber(highest: number | null, bumpMajor: boolean): number {
+    if (highest == null) {
+      return bumpMajor ? JobVersionService.encodeVersionNumber(1, 0) : JobVersionService.encodeVersionNumber(0, 1);
+    }
+    const { major, minor } = JobVersionService.decodeVersionNumber(highest);
+    return bumpMajor ? JobVersionService.encodeVersionNumber(major + 1, 0) : JobVersionService.encodeVersionNumber(major, minor + 1);
+  }
+
+  static isVisibleToCustomer(version: { visibleToCustomer?: boolean | null; authorRole: JobVersionAuthorRole }): boolean {
+    if (version.authorRole === JobVersionAuthorRole.CUSTOMER) return true;
+    return version.visibleToCustomer !== false;
+  }
+
+  static filterVisibleToCustomer<T extends { visibleToCustomer?: boolean | null; authorRole: JobVersionAuthorRole }>(versions: T[]): T[] {
+    return versions.filter((v) => JobVersionService.isVisibleToCustomer(v));
+  }
+
+  static latestContentVersionNumber(versions: { versionNumber: number; isEvent?: boolean | null }[]): number | null {
+    const content = versions.filter((v) => v.isEvent !== true).sort((a, b) => b.versionNumber - a.versionNumber);
+    return content[0]?.versionNumber ?? null;
+  }
+
   // ---------------------------------------------------------------- baseline
 
   /**
@@ -161,7 +213,9 @@ export class JobVersionService {
         createdBy: job.sub ?? '',
         createdByName: job.clientDisplayName || job.username || job.email || '',
         note: 'Original submission',
-        createdAt: job.submitted ?? new Date()
+        createdAt: job.submitted ?? new Date(),
+        bumpMajor: true,
+        visibleToCustomer: true
       });
       return [created];
     } catch (error: any) {
@@ -234,11 +288,21 @@ export class JobVersionService {
   async appendVersion(
     job: Job,
     workflows: JobVersionWorkflow[],
-    meta: { authorRole: JobVersionAuthorRole; createdBy: string; createdByName: string; note?: string; createdAt?: Date; jobState?: JobState; isEvent?: boolean }
+    meta: {
+      authorRole: JobVersionAuthorRole;
+      createdBy: string;
+      createdByName: string;
+      note?: string;
+      createdAt?: Date;
+      jobState?: JobState;
+      isEvent?: boolean;
+      bumpMajor?: boolean;
+      visibleToCustomer?: boolean;
+    }
   ): Promise<JobVersion> {
     const jobId = String(job._id);
     const highest = await this.versionModel.findOne({ jobId }).sort({ versionNumber: -1 }).exec();
-    const versionNumber = (highest?.versionNumber ?? 0) + 1;
+    const versionNumber = JobVersionService.nextVersionNumber(highest?.versionNumber ?? null, meta.bumpMajor === true);
 
     return this.versionModel.create({
       job: new mongoose.Types.ObjectId(jobId),
@@ -251,6 +315,7 @@ export class JobVersionService {
       // moving *to* rather than whatever the in-memory job still says.
       jobState: meta.jobState ?? job.state,
       isEvent: meta.isEvent === true,
+      visibleToCustomer: meta.visibleToCustomer === true,
       createdBy: meta.createdBy,
       createdByName: meta.createdByName,
       createdAt: meta.createdAt ?? new Date()
@@ -288,7 +353,9 @@ export class JobVersionService {
       createdByName: author.name,
       note,
       jobState: newState,
-      isEvent: true
+      isEvent: true,
+      visibleToCustomer: true,
+      bumpMajor: newState === JobState.CHANGES_REQUESTED
     });
   }
 
@@ -315,17 +382,36 @@ export class JobVersionService {
     const prepared = await this.prepareWorkflows(input.workflows, job.customerCategory as CustomerCategory | undefined);
     this.assertWorkInFlightUntouched(liveNodes, prepared);
 
+    // Which nodes existed before this save, across every tree. Node deletion is
+    // decided once, globally, at the end — never per tree.
+    //
+    // Trees are recomputed from connectivity on each save, so a node routinely
+    // migrates between them: deleting an edge splits one tree into two, adding
+    // one merges two into one. A per-tree rule reads such a node as "dropped"
+    // while the tree that now owns it is still wiring edges to it, leaving an
+    // edge pointing at a deleted node — which makes the whole job unreadable.
+    const nodeIdsBefore = await this.collectJobNodeIds(job);
+
     const workflowIds: mongoose.Types.ObjectId[] = [];
+    const keptNodeIds = new Set<string>();
     for (let i = 0; i < input.workflows.length; i++) {
-      const id = await this.reconcileWorkflow(input.workflows[i], prepared[i], liveNodes);
-      workflowIds.push(id);
+      const { workflowId, nodeIds } = await this.reconcileWorkflow(input.workflows[i], prepared[i], liveNodes);
+      workflowIds.push(workflowId);
+      for (const nodeId of nodeIds) keptNodeIds.add(String(nodeId));
     }
 
-    // Workflows the edit emptied or removed entirely.
+    // Workflows the edit emptied or removed entirely. Their nodes are left to
+    // the global pass below, since a "removed" tree is often just one whose
+    // nodes now live in a tree that survived.
     const keptIds = new Set(workflowIds.map(String));
     for (const ref of job.workflows ?? []) {
       if (keptIds.has(String(ref))) continue;
       await this.deleteWorkflow(String(ref));
+    }
+
+    const removedNodeIds = nodeIdsBefore.filter((nodeId) => !keptNodeIds.has(nodeId));
+    if (removedNodeIds.length) {
+      await this.nodeModel.deleteMany({ _id: { $in: removedNodeIds } }).exec();
     }
 
     await this.jobModel.findByIdAndUpdate(job._id, { $set: { workflows: workflowIds } }).exec();
@@ -336,10 +422,21 @@ export class JobVersionService {
       authorRole: author.role,
       createdBy: author.sub,
       createdByName: author.name,
-      note
+      note,
+      visibleToCustomer: author.role === JobVersionAuthorRole.CUSTOMER
     });
 
     return refreshed!;
+  }
+
+  /** Database ids of every node the job currently owns, across all its trees. */
+  private async collectJobNodeIds(job: Job): Promise<string[]> {
+    const ids = new Set<string>();
+    for (const workflowRef of job.workflows ?? []) {
+      const workflow = await this.workflowModel.findById(String(workflowRef)).exec();
+      for (const nodeRef of workflow?.nodes ?? []) ids.add(String(nodeRef));
+    }
+    return [...ids];
   }
 
   /** Every live node on the job, keyed by client-side id. */
@@ -439,7 +536,15 @@ export class JobVersionService {
   }
 
   /** Apply one tree to the live documents, returning the Workflow id it landed in. */
-  private async reconcileWorkflow(input: SaveWorkflowInput, prepared: PreparedNode[], liveNodes: Map<string, LiveNode>): Promise<mongoose.Types.ObjectId> {
+  /**
+   * Persist one tree. Returns the workflow id plus the node ids it now owns, so
+   * `saveWorkflows` can decide deletion across every tree at once.
+   */
+  private async reconcileWorkflow(
+    input: SaveWorkflowInput,
+    prepared: PreparedNode[],
+    liveNodes: Map<string, LiveNode>
+  ): Promise<{ workflowId: mongoose.Types.ObjectId; nodeIds: mongoose.Types.ObjectId[] }> {
     const nodeDbIdByClientId = new Map<string, mongoose.Types.ObjectId>();
 
     for (const node of prepared) {
@@ -494,14 +599,12 @@ export class JobVersionService {
     const nodeIds = prepared.map((n) => nodeDbIdByClientId.get(n.clientId)!).filter(Boolean);
 
     if (existing) {
-      // Nodes dropped from this tree. Nodes that merely moved to another tree in
-      // the same save are spared — they are still referenced somewhere.
-      const stillHere = new Set(nodeIds.map(String));
-      const orphaned = (existing.nodes ?? []).map((n: any) => String(n)).filter((id) => !stillHere.has(id));
-      if (orphaned.length) await this.nodeModel.deleteMany({ _id: { $in: orphaned } }).exec();
-
+      // Deliberately no node deletion here: a node missing from this tree may
+      // have migrated to another tree in the same save, which has not
+      // necessarily been reconciled yet. `saveWorkflows` deletes globally once
+      // every tree has claimed its nodes.
       await this.workflowModel.findByIdAndUpdate(existing._id, { $set: { nodes: nodeIds, edges: edgeIds, name: input.name ?? existing.name } }).exec();
-      return toObjectId(existing._id);
+      return { workflowId: toObjectId(existing._id), nodeIds };
     }
 
     const created = await this.workflowModel.create({
@@ -510,13 +613,18 @@ export class JobVersionService {
       edges: edgeIds,
       state: WorkflowState.QUEUED
     });
-    return toObjectId(created._id);
+    return { workflowId: toObjectId(created._id), nodeIds };
   }
 
+  /**
+   * Drop a workflow and its edges. Nodes are left alone on purpose — a workflow
+   * disappears whenever trees are re-partitioned (an added edge merging two into
+   * one), and its nodes are usually alive in the tree that absorbed them.
+   * `saveWorkflows` deletes the genuinely removed ones globally.
+   */
   private async deleteWorkflow(workflowId: string): Promise<void> {
     const workflow = await this.workflowModel.findById(workflowId).exec();
     if (!workflow) return;
-    await this.nodeModel.deleteMany({ _id: { $in: (workflow.nodes ?? []).map((n: any) => String(n)) } }).exec();
     await this.edgeModel.deleteMany({ _id: { $in: (workflow.edges ?? []).map((e: any) => String(e)) } }).exec();
     await this.workflowModel.findByIdAndDelete(workflowId).exec();
   }

--- a/src/job-version/job-version.service.ts
+++ b/src/job-version/job-version.service.ts
@@ -1,0 +1,474 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import mongoose, { HydratedDocument, Model } from 'mongoose';
+import { JobVersion, JobVersionAuthorRole, JobVersionDocument, JobVersionEdge, JobVersionNode, JobVersionWorkflow } from './job-version.model';
+import { SaveJobWorkflowsInput, SaveWorkflowInput } from './job-version.dto';
+import { Job, JobDocument } from '../job/job.model';
+import { Workflow, WorkflowDocument, WorkflowState } from '../workflow/models/workflow.model';
+import { WorkflowNode, WorkflowNodeDocument, WorkflowNodeState } from '../workflow/models/node.model';
+import { WorkflowEdge, WorkflowEdgeDocument } from '../workflow/models/edge.model';
+import { DampLabServices } from '../services/damplab-services.services';
+import { getMultiValueParamIds, normalizeFormDataToArray } from '../workflow/utils/form-data.util';
+import { calculateServiceCost, CustomerCategory, RUN_COUNT_PARAM_ID } from '../pricing/service-pricing.util';
+
+/** Fields on a live WorkflowNode that a save is allowed to write. Everything else — state, assigneeId, startedAt, completedSteps, usedInventory, inventory reservations — belongs to the lab and is never touched here. */
+type NodeContentPatch = {
+  label: string;
+  service: mongoose.Types.ObjectId;
+  additionalInstructions: string;
+  formData: unknown;
+  price: number | undefined;
+  reactNode: Record<string, unknown>;
+};
+
+/** Mongoose models declare `_id: string` on these classes, so ids come back needing a widening conversion. */
+const toObjectId = (value: unknown): mongoose.Types.ObjectId => new mongoose.Types.ObjectId(String(value));
+
+/** A live node as mongoose hands it back. */
+type LiveNode = HydratedDocument<WorkflowNode>;
+
+/** A node resolved against the catalogue and priced, ready to write. */
+interface PreparedNode {
+  clientId: string;
+  patch: NodeContentPatch;
+  snapshot: JobVersionNode;
+}
+
+/** True for a value that carries no information: never counted as an edit. */
+function isEmptyParamValue(value: unknown): boolean {
+  if (value === null || value === undefined || value === '') return true;
+  if (Array.isArray(value)) return value.every((v) => v === null || v === undefined || v === '');
+  return false;
+}
+
+function paramValuesById(formData: unknown): Map<string, unknown> {
+  const byId = new Map<string, unknown>();
+  const entries = Array.isArray(formData) ? formData : [];
+  for (const entry of entries) {
+    if (entry && typeof entry === 'object' && typeof (entry as { id?: unknown }).id === 'string') {
+      byId.set((entry as { id: string }).id, (entry as { value?: unknown }).value ?? null);
+    }
+  }
+  // An absent run count means one run — that is how pricing reads it — so a
+  // stored node from before the universal run-count entry existed must compare
+  // equal to an editor payload that spells the default out.
+  if (!byId.has(RUN_COUNT_PARAM_ID)) byId.set(RUN_COUNT_PARAM_ID, 1);
+  return byId;
+}
+
+/**
+ * Whether a user actually changed a node's parameters.
+ *
+ * Set membership alone will not do. The editor always submits the *current*
+ * catalogue's parameter list, so a parameter added to the service since the job
+ * was submitted arrives with an empty value, and the universal run-count entry
+ * appears on jobs that predate it. Neither is something the user touched, and
+ * treating them as edits would make every in-flight node unsaveable on any
+ * service whose parameters have since been edited.
+ *
+ * So: compare values, and ignore an id that is empty on the side where it is
+ * missing.
+ */
+function parametersDiffer(before: unknown, after: unknown): boolean {
+  const beforeById = paramValuesById(before);
+  const afterById = paramValuesById(after);
+
+  for (const id of new Set([...beforeById.keys(), ...afterById.keys()])) {
+    const hasBefore = beforeById.has(id);
+    const hasAfter = afterById.has(id);
+    const beforeValue = beforeById.get(id);
+    const afterValue = afterById.get(id);
+
+    // Present on one side only: an edit only if that side carries a real value.
+    if (!hasBefore) {
+      if (!isEmptyParamValue(afterValue)) return true;
+      continue;
+    }
+    if (!hasAfter) {
+      if (!isEmptyParamValue(beforeValue)) return true;
+      continue;
+    }
+    if (isEmptyParamValue(beforeValue) && isEmptyParamValue(afterValue)) continue;
+    // A number typed into a text field arrives as a string; "10" and 10 are the
+    // same parameter value and must not read as an edit.
+    if (String(beforeValue) === String(afterValue)) continue;
+    if (JSON.stringify(beforeValue) !== JSON.stringify(afterValue)) return true;
+  }
+
+  return false;
+}
+
+@Injectable()
+export class JobVersionService {
+  constructor(
+    @InjectModel(JobVersion.name) private readonly versionModel: Model<JobVersionDocument>,
+    @InjectModel(Job.name) private readonly jobModel: Model<JobDocument>,
+    @InjectModel(Workflow.name) private readonly workflowModel: Model<WorkflowDocument>,
+    @InjectModel(WorkflowNode.name) private readonly nodeModel: Model<WorkflowNodeDocument>,
+    @InjectModel(WorkflowEdge.name) private readonly edgeModel: Model<WorkflowEdgeDocument>,
+    private readonly dampLabServices: DampLabServices
+  ) {}
+
+  // ---------------------------------------------------------------- baseline
+
+  /**
+   * The version `versionNumber` should be compared against.
+   *
+   * Keys off the *author of the version being viewed*, not off the viewer, so
+   * both parties see the same diff — they are discussing one change set, not
+   * two. Consecutive saves by one party therefore collapse into a single diff
+   * against the other party's last version, which is what makes "the customer's
+   * edits relative to the one sent to them" work after the customer saved twice.
+   *
+   * Returns null when nothing below it was written by the other side.
+   */
+  static baselineFor(versions: Pick<JobVersion, 'versionNumber' | 'authorRole'>[], versionNumber: number): number | null {
+    const current = versions.find((v) => v.versionNumber === versionNumber);
+    if (!current) return null;
+
+    const earlierByOtherSide = versions.filter((v) => v.versionNumber < versionNumber && v.authorRole !== current.authorRole).sort((a, b) => b.versionNumber - a.versionNumber);
+
+    return earlierByOtherSide.length ? earlierByOtherSide[0].versionNumber : null;
+  }
+
+  // ----------------------------------------------------------------- reading
+
+  /**
+   * Every version of a job, oldest first.
+   *
+   * Jobs submitted before versioning existed have no v1, so one is synthesized
+   * from their live workflows on first read and persisted. That keeps the
+   * backfill lazy — no migration script — and idempotent.
+   */
+  async listByJob(jobId: string): Promise<JobVersion[]> {
+    const existing = await this.versionModel.find({ jobId }).sort({ versionNumber: 1 }).exec();
+    if (existing.length > 0) return existing;
+
+    const job = await this.jobModel.findById(jobId).exec();
+    if (!job) return [];
+
+    const workflows = await this.snapshotLiveWorkflows(job);
+    if (workflows.length === 0) return [];
+
+    try {
+      const created = await this.appendVersion(job, workflows, {
+        authorRole: JobVersionAuthorRole.CUSTOMER,
+        createdBy: job.sub ?? '',
+        createdByName: job.clientDisplayName || job.username || job.email || '',
+        note: 'Original submission',
+        createdAt: job.submitted ?? new Date()
+      });
+      return [created];
+    } catch (error: any) {
+      // Two concurrent loads of the same legacy job both see zero versions and
+      // both try to write v1; the unique index makes one lose. That is the
+      // backfill working, not a failure — re-read and use whichever won.
+      if (error?.code !== 11000) throw error;
+      return this.versionModel.find({ jobId }).sort({ versionNumber: 1 }).exec();
+    }
+  }
+
+  /** The live workflow graph, in the denormalized shape a version stores. */
+  async snapshotLiveWorkflows(job: Job): Promise<JobVersionWorkflow[]> {
+    const snapshots: JobVersionWorkflow[] = [];
+
+    for (const workflowRef of job.workflows ?? []) {
+      const workflow = await this.workflowModel.findById(String(workflowRef)).exec();
+      if (!workflow) continue;
+
+      const nodeIds = (workflow.nodes ?? []).map((n: any) => String(n));
+      const nodeDocs = await this.nodeModel.find({ _id: { $in: nodeIds } }).exec();
+      // Preserve the workflow's own node ordering; $in does not guarantee it.
+      const nodeByDbId = new Map<string, LiveNode>(nodeDocs.map((n) => [String(n._id), n as LiveNode]));
+      const orderedNodes = nodeIds.flatMap((id) => {
+        const node = nodeByDbId.get(id);
+        return node ? [node] : [];
+      });
+
+      const edgeIds = (workflow.edges ?? []).map((e: any) => String(e));
+      const edgeDocs = await this.edgeModel.find({ _id: { $in: edgeIds } }).exec();
+
+      // Edges reference nodes by database id; snapshots reference them by
+      // client-side id, which is what the canvas and the diff both speak.
+      const clientIdByDbId = new Map(orderedNodes.map((n) => [String(n._id), n.id]));
+
+      snapshots.push({
+        workflowId: String(workflow._id),
+        name: workflow.name ?? '',
+        nodes: orderedNodes.map((node) => this.nodeSnapshot(node)),
+        edges: edgeDocs
+          .map((edge) => ({
+            id: edge.id,
+            source: clientIdByDbId.get(String(edge.source)) ?? '',
+            target: clientIdByDbId.get(String(edge.target)) ?? ''
+          }))
+          .filter((e): e is JobVersionEdge => !!e.source && !!e.target)
+      });
+    }
+
+    return snapshots;
+  }
+
+  private nodeSnapshot(node: LiveNode): JobVersionNode {
+    const position = (node.reactNode as any)?.position;
+    return {
+      id: node.id,
+      label: node.label ?? '',
+      serviceId: node.service ? String((node.service as any)?._id ?? node.service) : undefined,
+      serviceName: node.label ?? '',
+      formData: Array.isArray(node.formData) ? node.formData : [],
+      additionalInstructions: node.additionalInstructions ?? '',
+      price: node.price,
+      position: position && typeof position.x === 'number' && typeof position.y === 'number' ? { x: position.x, y: position.y } : undefined
+    };
+  }
+
+  // ----------------------------------------------------------------- writing
+
+  /** Append a snapshot as the next version. The only way a version is ever created. */
+  async appendVersion(
+    job: Job,
+    workflows: JobVersionWorkflow[],
+    meta: { authorRole: JobVersionAuthorRole; createdBy: string; createdByName: string; note?: string; createdAt?: Date }
+  ): Promise<JobVersion> {
+    const jobId = String(job._id);
+    const highest = await this.versionModel.findOne({ jobId }).sort({ versionNumber: -1 }).exec();
+    const versionNumber = (highest?.versionNumber ?? 0) + 1;
+
+    return this.versionModel.create({
+      job: new mongoose.Types.ObjectId(jobId),
+      jobId,
+      versionNumber,
+      authorRole: meta.authorRole,
+      workflows,
+      note: meta.note,
+      createdBy: meta.createdBy,
+      createdByName: meta.createdByName,
+      createdAt: meta.createdAt ?? new Date()
+    });
+  }
+
+  /**
+   * Replace a job's workflow graph and record the result as a new version.
+   *
+   * Live documents are reconciled node by node rather than rebuilt, so a node
+   * that is already assigned, started or holding inventory keeps all of it.
+   */
+  async saveWorkflows(input: SaveJobWorkflowsInput, author: { role: JobVersionAuthorRole; sub: string; name: string }): Promise<Job> {
+    const job = await this.jobModel.findById(input.jobId).exec();
+    if (!job) throw new NotFoundException(`Job with ID ${input.jobId} not found`);
+
+    const liveNodes = await this.loadLiveNodes(job);
+
+    // Prepared first, deliberately: it resolves each node against the catalogue
+    // and normalizes formData, so the guard below compares like with like. It
+    // only reads, so nothing is written if the guard then rejects.
+    const prepared = await this.prepareWorkflows(input.workflows, job.customerCategory as CustomerCategory | undefined);
+    this.assertWorkInFlightUntouched(liveNodes, prepared);
+
+    const workflowIds: mongoose.Types.ObjectId[] = [];
+    for (let i = 0; i < input.workflows.length; i++) {
+      const id = await this.reconcileWorkflow(input.workflows[i], prepared[i], liveNodes);
+      workflowIds.push(id);
+    }
+
+    // Workflows the edit emptied or removed entirely.
+    const keptIds = new Set(workflowIds.map(String));
+    for (const ref of job.workflows ?? []) {
+      if (keptIds.has(String(ref))) continue;
+      await this.deleteWorkflow(String(ref));
+    }
+
+    await this.jobModel.findByIdAndUpdate(job._id, { $set: { workflows: workflowIds } }).exec();
+
+    const refreshed = await this.jobModel.findById(job._id).exec();
+    const snapshot = await this.snapshotLiveWorkflows(refreshed!);
+    await this.appendVersion(refreshed!, snapshot, {
+      authorRole: author.role,
+      createdBy: author.sub,
+      createdByName: author.name,
+      note: input.note
+    });
+
+    return refreshed!;
+  }
+
+  /** Every live node on the job, keyed by client-side id. */
+  private async loadLiveNodes(job: Job): Promise<Map<string, LiveNode>> {
+    const byClientId = new Map<string, LiveNode>();
+    for (const workflowRef of job.workflows ?? []) {
+      const workflow = await this.workflowModel.findById(String(workflowRef)).exec();
+      if (!workflow) continue;
+      const nodes = await this.nodeModel.find({ _id: { $in: (workflow.nodes ?? []).map((n: any) => String(n)) } }).exec();
+      for (const node of nodes) byClientId.set(node.id, node as LiveNode);
+    }
+    return byClientId;
+  }
+
+  /**
+   * Work already under way is not the editor's to change.
+   *
+   * A node that has left QUEUED, or is holding inventory, may not be deleted or
+   * have its service or parameters altered. The UI locks these too, but the UI
+   * must never be the only guard — a stale tab or a direct API call would
+   * otherwise orphan an inventory hold or silently rewrite a protocol a
+   * technician is midway through.
+   */
+  private assertWorkInFlightUntouched(liveNodes: Map<string, LiveNode>, prepared: PreparedNode[][]): void {
+    const preparedById = new Map<string, PreparedNode>();
+    for (const workflow of prepared) {
+      for (const node of workflow) preparedById.set(node.clientId, node);
+    }
+
+    for (const [clientId, live] of liveNodes) {
+      const isInFlight = live.state !== WorkflowNodeState.QUEUED;
+      const holdsInventory = (live.usedInventory ?? []).length > 0;
+      if (!isInFlight && !holdsInventory) continue;
+
+      const reason = isInFlight ? `is ${WorkflowNodeState[live.state]}` : 'is holding inventory';
+      const submitted = preparedById.get(clientId);
+      if (!submitted) {
+        throw new BadRequestException(`"${live.label}" cannot be removed because it ${reason}.`);
+      }
+      if (String(submitted.patch.service) !== String((live.service as any)?._id ?? live.service)) {
+        throw new BadRequestException(`"${live.label}" cannot change service because it ${reason}.`);
+      }
+      if (parametersDiffer(live.formData, submitted.patch.formData)) {
+        throw new BadRequestException(`"${live.label}" cannot have its parameters changed because it ${reason}.`);
+      }
+    }
+  }
+
+  /**
+   * Resolve every node against the live catalogue and price it.
+   *
+   * Prices are recomputed from the job's own customer category, never the
+   * editing user's — otherwise a technician saving a customer's job would
+   * silently reprice it at staff rates.
+   */
+  private async prepareWorkflows(workflows: SaveWorkflowInput[], category: CustomerCategory | undefined): Promise<PreparedNode[][]> {
+    const serviceIds = [...new Set(workflows.flatMap((w) => w.nodes.map((n) => String(n.serviceId))))];
+    const services = new Map<string, any>();
+    for (const id of serviceIds) {
+      const service = await this.dampLabServices.findOneActive(id);
+      if (!service) throw new BadRequestException(`DampLabService with ID ${id} does not exist or is deleted`);
+      services.set(id, service);
+    }
+
+    return workflows.map((workflow) =>
+      workflow.nodes.map((node) => {
+        const service = services.get(String(node.serviceId));
+        const formData = normalizeFormDataToArray(node.formData, getMultiValueParamIds(service.parameters));
+        const price = calculateServiceCost(service, formData, undefined, category);
+        const position = node.position ? { x: node.position.x, y: node.position.y } : undefined;
+
+        return {
+          clientId: node.id,
+          patch: {
+            label: node.label ?? service.name,
+            service: new mongoose.Types.ObjectId(String(service._id)),
+            additionalInstructions: node.additionalInstructions ?? '',
+            formData,
+            price,
+            // Minimal, so nothing the client invented can ride along. Hydration
+            // reads only `position` back out of this.
+            reactNode: { id: node.id, type: 'selectorNode', position: position ?? { x: 0, y: 0 } }
+          },
+          snapshot: {
+            id: node.id,
+            label: node.label ?? service.name,
+            serviceId: String(service._id),
+            serviceName: service.name,
+            formData,
+            additionalInstructions: node.additionalInstructions ?? '',
+            price,
+            position
+          }
+        };
+      })
+    );
+  }
+
+  /** Apply one tree to the live documents, returning the Workflow id it landed in. */
+  private async reconcileWorkflow(input: SaveWorkflowInput, prepared: PreparedNode[], liveNodes: Map<string, LiveNode>): Promise<mongoose.Types.ObjectId> {
+    const nodeDbIdByClientId = new Map<string, mongoose.Types.ObjectId>();
+
+    for (const node of prepared) {
+      const live = liveNodes.get(node.clientId);
+      if (live) {
+        // Named fields only — never a spread. This is what stops a UI-only flag
+        // (ghost, locked, diffKind) from ever reaching the database, and what
+        // keeps state/assignee/startedAt/completedSteps/usedInventory intact.
+        await this.nodeModel
+          .findByIdAndUpdate(live._id, {
+            $set: {
+              label: node.patch.label,
+              service: node.patch.service,
+              additionalInstructions: node.patch.additionalInstructions,
+              formData: node.patch.formData,
+              price: node.patch.price,
+              reactNode: node.patch.reactNode
+            }
+          })
+          .exec();
+        nodeDbIdByClientId.set(node.clientId, toObjectId(live._id));
+      } else {
+        const created = await this.nodeModel.create({
+          id: node.clientId,
+          label: node.patch.label,
+          service: node.patch.service,
+          additionalInstructions: node.patch.additionalInstructions,
+          formData: node.patch.formData,
+          price: node.patch.price,
+          reactNode: node.patch.reactNode,
+          state: WorkflowNodeState.QUEUED
+        });
+        nodeDbIdByClientId.set(node.clientId, toObjectId(created._id));
+      }
+    }
+
+    // Edges carry no operational state, so they are cheapest to replace outright.
+    const existing = input.workflowId ? await this.workflowModel.findById(input.workflowId).exec() : null;
+    if (existing) {
+      await this.edgeModel.deleteMany({ _id: { $in: (existing.edges ?? []).map((e: any) => String(e)) } }).exec();
+    }
+
+    const edgeIds: mongoose.Types.ObjectId[] = [];
+    for (const edge of input.edges) {
+      const source = nodeDbIdByClientId.get(edge.source);
+      const target = nodeDbIdByClientId.get(edge.target);
+      if (!source || !target) continue; // edge to a node this tree does not own
+      const created = await this.edgeModel.create({ id: edge.id, source, target, reactEdge: { id: edge.id, source: edge.source, target: edge.target } });
+      edgeIds.push(toObjectId(created._id));
+    }
+
+    const nodeIds = prepared.map((n) => nodeDbIdByClientId.get(n.clientId)!).filter(Boolean);
+
+    if (existing) {
+      // Nodes dropped from this tree. Nodes that merely moved to another tree in
+      // the same save are spared — they are still referenced somewhere.
+      const stillHere = new Set(nodeIds.map(String));
+      const orphaned = (existing.nodes ?? []).map((n: any) => String(n)).filter((id) => !stillHere.has(id));
+      if (orphaned.length) await this.nodeModel.deleteMany({ _id: { $in: orphaned } }).exec();
+
+      await this.workflowModel.findByIdAndUpdate(existing._id, { $set: { nodes: nodeIds, edges: edgeIds, name: input.name ?? existing.name } }).exec();
+      return toObjectId(existing._id);
+    }
+
+    const created = await this.workflowModel.create({
+      name: input.name ?? `Workflow-${prepared[0]?.clientId ?? ''}`,
+      nodes: nodeIds,
+      edges: edgeIds,
+      state: WorkflowState.QUEUED
+    });
+    return toObjectId(created._id);
+  }
+
+  private async deleteWorkflow(workflowId: string): Promise<void> {
+    const workflow = await this.workflowModel.findById(workflowId).exec();
+    if (!workflow) return;
+    await this.nodeModel.deleteMany({ _id: { $in: (workflow.nodes ?? []).map((n: any) => String(n)) } }).exec();
+    await this.edgeModel.deleteMany({ _id: { $in: (workflow.edges ?? []).map((e: any) => String(e)) } }).exec();
+    await this.workflowModel.findByIdAndDelete(workflowId).exec();
+  }
+}

--- a/src/job-version/job-version.service.ts
+++ b/src/job-version/job-version.service.ts
@@ -3,7 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import mongoose, { HydratedDocument, Model } from 'mongoose';
 import { JobVersion, JobVersionAuthorRole, JobVersionDocument, JobVersionEdge, JobVersionNode, JobVersionWorkflow } from './job-version.model';
 import { SaveJobWorkflowsInput, SaveWorkflowInput } from './job-version.dto';
-import { Job, JobDocument } from '../job/job.model';
+import { Job, JobDocument, JobState } from '../job/job.model';
 import { Workflow, WorkflowDocument, WorkflowState } from '../workflow/models/workflow.model';
 import { WorkflowNode, WorkflowNodeDocument, WorkflowNodeState } from '../workflow/models/node.model';
 import { WorkflowEdge, WorkflowEdgeDocument } from '../workflow/models/edge.model';
@@ -120,13 +120,18 @@ export class JobVersionService {
    * against the other party's last version, which is what makes "the customer's
    * edits relative to the one sent to them" work after the customer saved twice.
    *
+   * Event versions are never chosen: their graph is a verbatim copy of the
+   * version before them, so baselining against one reports "nothing changed" and
+   * hides the edit it followed. Closing a job right after the customer edited it
+   * would otherwise erase the highlight on those very edits.
+   *
    * Returns null when nothing below it was written by the other side.
    */
-  static baselineFor(versions: Pick<JobVersion, 'versionNumber' | 'authorRole'>[], versionNumber: number): number | null {
+  static baselineFor(versions: Pick<JobVersion, 'versionNumber' | 'authorRole' | 'isEvent'>[], versionNumber: number): number | null {
     const current = versions.find((v) => v.versionNumber === versionNumber);
     if (!current) return null;
 
-    const earlierByOtherSide = versions.filter((v) => v.versionNumber < versionNumber && v.authorRole !== current.authorRole).sort((a, b) => b.versionNumber - a.versionNumber);
+    const earlierByOtherSide = versions.filter((v) => v.versionNumber < versionNumber && v.authorRole !== current.authorRole && v.isEvent !== true).sort((a, b) => b.versionNumber - a.versionNumber);
 
     return earlierByOtherSide.length ? earlierByOtherSide[0].versionNumber : null;
   }
@@ -229,7 +234,7 @@ export class JobVersionService {
   async appendVersion(
     job: Job,
     workflows: JobVersionWorkflow[],
-    meta: { authorRole: JobVersionAuthorRole; createdBy: string; createdByName: string; note?: string; createdAt?: Date }
+    meta: { authorRole: JobVersionAuthorRole; createdBy: string; createdByName: string; note?: string; createdAt?: Date; jobState?: JobState; isEvent?: boolean }
   ): Promise<JobVersion> {
     const jobId = String(job._id);
     const highest = await this.versionModel.findOne({ jobId }).sort({ versionNumber: -1 }).exec();
@@ -242,9 +247,48 @@ export class JobVersionService {
       authorRole: meta.authorRole,
       workflows,
       note: meta.note,
+      // Explicit override first, so a transition can record the state it is
+      // moving *to* rather than whatever the in-memory job still says.
+      jobState: meta.jobState ?? job.state,
+      isEvent: meta.isEvent === true,
       createdBy: meta.createdBy,
       createdByName: meta.createdByName,
       createdAt: meta.createdAt ?? new Date()
+    });
+  }
+
+  /**
+   * Record a state change as a version of its own.
+   *
+   * The graph is unchanged, so the snapshot is identical to its predecessor and
+   * the entry diffs empty — which is the point. Without it the history is only
+   * the saves, and the events between them (a customer resubmitting, staff
+   * asking for changes) leave no trace at all, so a state chip on the save rows
+   * would show nearly the same value on every row.
+   *
+   * Modelled on the SOW's event versions, which exist for the same reason.
+   */
+  async appendStateEvent(job: Job, newState: JobState, author: { role: JobVersionAuthorRole; sub: string; name: string }, note: string): Promise<JobVersion | null> {
+    // Force the lazy v1 backfill first. On a job submitted before versioning
+    // existed the event would otherwise be written as version 1, and listByJob
+    // only backfills when it finds *no* versions — so the original submission
+    // would be permanently unrecoverable and the history would begin with
+    // "Changes requested" against nothing.
+    await this.listByJob(String(job._id));
+
+    // Nothing to snapshot means a job with no workflows; there is no history to
+    // add an event to, and the lazy v1 backfill would be confused by a v1 that
+    // carries no graph.
+    const workflows = await this.snapshotLiveWorkflows(job);
+    if (workflows.length === 0) return null;
+
+    return this.appendVersion(job, workflows, {
+      authorRole: author.role,
+      createdBy: author.sub,
+      createdByName: author.name,
+      note,
+      jobState: newState,
+      isEvent: true
     });
   }
 
@@ -257,6 +301,11 @@ export class JobVersionService {
   async saveWorkflows(input: SaveJobWorkflowsInput, author: { role: JobVersionAuthorRole; sub: string; name: string }): Promise<Job> {
     const job = await this.jobModel.findById(input.jobId).exec();
     if (!job) throw new NotFoundException(`Job with ID ${input.jobId} not found`);
+
+    // Non-nullable in the schema already stops an omitted note; this catches the
+    // whitespace-only one, which would satisfy the type and tell a reader nothing.
+    const note = input.note?.trim();
+    if (!note) throw new BadRequestException('Describe what you changed before saving.');
 
     const liveNodes = await this.loadLiveNodes(job);
 
@@ -287,7 +336,7 @@ export class JobVersionService {
       authorRole: author.role,
       createdBy: author.sub,
       createdByName: author.name,
-      note: input.note
+      note
     });
 
     return refreshed!;

--- a/src/job/job.module.ts
+++ b/src/job/job.module.ts
@@ -12,6 +12,7 @@ import { SOWModule } from '../sow/sow.module';
 import { JobAttachmentsService } from './job-attachments.service';
 import { JobFeedStatusEntity, JobFeedStatusEntitySchema } from './job-feed-status.model';
 import { ActivityModule } from '../activity/activity.module';
+import { JobVersionModule } from '../job-version/job-version.module';
 
 @Module({
   imports: [
@@ -23,7 +24,8 @@ import { ActivityModule } from '../activity/activity.module';
     forwardRef(() => WorkflowModule),
     forwardRef(() => CommentModule),
     forwardRef(() => SOWModule),
-    ActivityModule
+    ActivityModule,
+    JobVersionModule
   ],
   providers: [JobService, JobResolver, CreateJobPipe, CommentService, JobAttachmentsService],
   exports: [JobService, JobAttachmentsService]

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -1,5 +1,5 @@
 import { UseGuards, Inject, forwardRef, Logger, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { Mutation, ResolveField, Resolver, Query, Args, Parent, ID } from '@nestjs/graphql';
+import { Mutation, ResolveField, Resolver, Query, Args, Parent, ID, Int } from '@nestjs/graphql';
 import { CreateJobInput, CreateJobPipe, CreateJobPreProcessed, JobAttachmentInput, JobAttachmentUpload, JobAttachmentUploadRequest, JobPipe } from './job.dto';
 import { OwnJobsInput, AllJobsInput, OwnJobsResult, JobsResult } from './dto/jobs-query.dto';
 import { Job, JobAttachment, JobState, CustomerCategory } from './job.model';
@@ -236,7 +236,9 @@ export class JobResolver {
       authorRole: this.authorRoleFor(user),
       createdBy: user.sub,
       createdByName: user.preferred_username ?? user.email ?? '',
-      note: 'Original submission'
+      note: 'Original submission',
+      bumpMajor: true,
+      visibleToCustomer: true
     });
 
     await this.activityService.createEvent({
@@ -556,9 +558,22 @@ export class JobResolver {
   }
 
   @ResolveField(() => [JobVersion], {
-    description: "Every saved version of this job's workflow graph, oldest first. Jobs submitted before versioning get a v1 synthesized from their live workflows on first read."
+    description:
+      "Saved versions of this job's workflow graph, oldest first. Staff see every row; customers see published rows plus their own."
   })
-  async versions(@Parent() job: Job): Promise<JobVersion[]> {
-    return this.jobVersionService.listByJob(String(job._id));
+  async versions(@Parent() job: Job, @CurrentUser() user: User): Promise<JobVersion[]> {
+    const all = await this.jobVersionService.listByJob(String(job._id));
+    const isStaff = (user?.realm_access?.roles ?? []).includes(Role.DamplabStaff);
+    return isStaff ? all : JobVersionService.filterVisibleToCustomer(all);
+  }
+
+  @ResolveField(() => Int, {
+    nullable: true,
+    description:
+      'Newest content versionNumber on the job, including unpublished staff drafts. Used by the editor conflict check; not a customer graph source.'
+  })
+  async latestContentVersionNumber(@Parent() job: Job): Promise<number | null> {
+    const all = await this.jobVersionService.listByJob(String(job._id));
+    return JobVersionService.latestContentVersionNumber(all);
   }
 }

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -558,8 +558,7 @@ export class JobResolver {
   }
 
   @ResolveField(() => [JobVersion], {
-    description:
-      "Saved versions of this job's workflow graph, oldest first. Staff see every row; customers see published rows plus their own."
+    description: "Saved versions of this job's workflow graph, oldest first. Staff see every row; customers see published rows plus their own."
   })
   async versions(@Parent() job: Job, @CurrentUser() user: User): Promise<JobVersion[]> {
     const all = await this.jobVersionService.listByJob(String(job._id));
@@ -569,8 +568,7 @@ export class JobResolver {
 
   @ResolveField(() => Int, {
     nullable: true,
-    description:
-      'Newest content versionNumber on the job, including unpublished staff drafts. Used by the editor conflict check; not a customer graph source.'
+    description: 'Newest content versionNumber on the job, including unpublished staff drafts. Used by the editor conflict check; not a customer graph source.'
   })
   async latestContentVersionNumber(@Parent() job: Job): Promise<number | null> {
     const all = await this.jobVersionService.listByJob(String(job._id));

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -16,6 +16,7 @@ import { User } from '../auth/user.interface';
 import { CurrentUser } from '../auth/user.decorator';
 import { SOW } from '../sow/sow.model';
 import { SOWService } from '../sow/sow.service';
+import { SowVersionService } from '../sow/sow-version.service';
 import { JobAttachmentsService } from './job-attachments.service';
 import { WorkflowNodeService } from '../workflow/services/node.service';
 import { UpdateSOWInput } from '../sow/dto/update-sow.input';
@@ -32,15 +33,19 @@ export class JobResolver {
    * Rebuild SOW line items from all workflows on the job (ordered nodes).
    * Keeps invoice / SOW in sync when workflows are added (e.g. addWorkflowToJob) or repriced.
    */
-  private async syncSowServicesFromJobWorkflows(jobId: string): Promise<void> {
-    const job = await this.jobService.findById(jobId);
-    if (!job) return;
-
-    const existingSow = await this.sowService.findByJobId(jobId);
-    if (!existingSow) return;
-
-    const existingServices = existingSow.services ?? [];
-
+  /**
+   * SOW line items for every node on the job's workflows, in workflow order.
+   *
+   * `existingServices` lets the sync path keep whatever staff have edited on a line
+   * that is still there. Creation passes nothing, because there is no prior
+   * document to preserve — and the positional match below is fragile enough that
+   * it should never be handed an array it was not built from.
+   *
+   * `formData` always travels with the line: service cost is recomputed downstream
+   * from the service record plus this data, and the run-count multiplier lives
+   * inside it.
+   */
+  private async collectSowServiceInputs(job: Job, existingServices: any[] = []): Promise<any[]> {
     const orderedNodes: any[] = [];
     for (const workflowId of job.workflows ?? []) {
       const workflow = await this.workflowService.findById(String(workflowId));
@@ -58,9 +63,7 @@ export class JobResolver {
       }
     }
 
-    if (orderedNodes.length === 0) return;
-
-    const servicesInput = orderedNodes.map((node: any, idx: number) => {
+    return orderedNodes.map((node: any, idx: number) => {
       const existing = existingServices[idx];
       const serviceId = String(node.service?._id ?? node.service);
 
@@ -73,9 +76,25 @@ export class JobResolver {
         formData: node.formData ?? []
       };
     });
+  }
+
+  private async syncSowServicesFromJobWorkflows(jobId: string): Promise<void> {
+    const job = await this.jobService.findById(jobId);
+    if (!job) return;
+
+    const existingSow = await this.sowService.findByJobId(jobId);
+    if (!existingSow) return;
+
+    const servicesInput = await this.collectSowServiceInputs(job, existingSow.services ?? []);
+    if (servicesInput.length === 0) return;
 
     const updateInput: UpdateSOWInput = { services: servicesInput } as any;
     await this.sowService.update(String(existingSow._id), updateInput);
+
+    // The billing core has moved; the SOW *document* has not. Flag it so staff
+    // see a banner and choose whether to revise, rather than silently rewriting a
+    // document that may already be sent, signed or finalized.
+    await this.sowVersionService.refreshDocumentStale(String(existingSow._id));
   }
 
   constructor(
@@ -87,6 +106,8 @@ export class JobResolver {
     private readonly commentService: CommentService,
     @Inject(forwardRef(() => SOWService))
     private readonly sowService: SOWService,
+    @Inject(forwardRef(() => SowVersionService))
+    private readonly sowVersionService: SowVersionService,
     private readonly jobAttachmentsService: JobAttachmentsService
   ) {}
 
@@ -286,6 +307,22 @@ export class JobResolver {
     await this.syncSowServicesFromJobWorkflows(jobId);
 
     return updatedJob ?? job;
+  }
+
+  @Mutation(() => SOW, {
+    description: "Staff-only. Create the first Statement of Work for a job, built from the job's workflows. Returns the existing SOW if the job already has one."
+  })
+  @Roles(Role.DamplabStaff)
+  async createSowForJob(@Args('jobId', { type: () => ID }) jobId: string, @CurrentUser() user: User): Promise<SOW> {
+    const job = await this.jobService.findById(jobId);
+    if (!job) {
+      throw new NotFoundException(`Job with ID ${jobId} not found`);
+    }
+
+    const services = await this.collectSowServiceInputs(job);
+    const createdBy = user.email || user.preferred_username || 'unknown';
+
+    return this.sowService.createForJob(jobId, services, createdBy);
   }
 
   @Mutation(() => [JobAttachmentUpload], {

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -23,6 +23,9 @@ import { UpdateSOWInput } from '../sow/dto/update-sow.input';
 import { JobFeedStatus } from './job-feed-status.model';
 import { ActivityService } from '../activity/activity.service';
 import { AddWorkflowInput, AddWorkflowInputFull, AddWorkflowInputPipe } from '../workflow/dtos/add-workflow.input';
+import { JobVersion, JobVersionAuthorRole } from '../job-version/job-version.model';
+import { JobVersionService } from '../job-version/job-version.service';
+import { SaveJobWorkflowsInput } from '../job-version/job-version.dto';
 
 @Resolver(() => Job)
 @UseGuards(AuthRolesGuard)
@@ -108,8 +111,18 @@ export class JobResolver {
     private readonly sowService: SOWService,
     @Inject(forwardRef(() => SowVersionService))
     private readonly sowVersionService: SowVersionService,
-    private readonly jobAttachmentsService: JobAttachmentsService
+    private readonly jobAttachmentsService: JobAttachmentsService,
+    private readonly jobVersionService: JobVersionService
   ) {}
+
+  /**
+   * Which side of the conversation a caller writes as. Staff editing their own
+   * job still write as STAFF — the baseline rule is about the two sides of the
+   * review, not about identity.
+   */
+  private authorRoleFor(user: User): JobVersionAuthorRole {
+    return (user.realm_access?.roles ?? []).includes(Role.DamplabStaff) ? JobVersionAuthorRole.STAFF : JobVersionAuthorRole.CUSTOMER;
+  }
 
   @Query(() => [Job])
   @Roles(Role.DamplabStaff)
@@ -203,6 +216,15 @@ export class JobResolver {
       email: user.email,
       customerCategory
     });
+    // v1 is the submission itself, so the first technician edit has something to
+    // diff against.
+    await this.jobVersionService.appendVersion(created, await this.jobVersionService.snapshotLiveWorkflows(created), {
+      authorRole: this.authorRoleFor(user),
+      createdBy: user.sub,
+      createdByName: user.preferred_username ?? user.email ?? '',
+      note: 'Original submission'
+    });
+
     await this.activityService.createEvent({
       type: 'JOB_SUBMITTED',
       message: `Job "${created.name}" was submitted`,
@@ -394,10 +416,71 @@ export class JobResolver {
     return updated;
   }
 
+  /**
+   * Staff, or the job's owner. Owners need this so "Resubmit job" can put a
+   * job that came back as CHANGES_REQUESTED into SUBMITTED again; they are held
+   * to exactly that transition so the customer cannot walk their own job
+   * through the lab's pipeline.
+   */
   @Mutation(() => Job)
-  @Roles(Role.DamplabStaff)
-  async changeJobState(@Args('job', { type: () => ID }, JobPipe) job: Job, @Args('newState', { type: () => JobState }) newState: JobState): Promise<Job> {
+  async changeJobState(@Args('job', { type: () => ID }, JobPipe) job: Job, @Args('newState', { type: () => JobState }) newState: JobState, @CurrentUser() user: User): Promise<Job> {
+    const isStaff = (user.realm_access?.roles ?? []).includes(Role.DamplabStaff);
+    if (!isStaff) {
+      const isOwner = job.sub === user.sub;
+      const isResubmission = job.state === JobState.CHANGES_REQUESTED && newState === JobState.SUBMITTED;
+      if (!isOwner || !isResubmission) {
+        throw new ForbiddenException('You do not have permission to change the state of this job');
+      }
+    }
     return (await this.jobService.updateState(job, newState))!;
+  }
+
+  /**
+   * Replace the job's workflow graph with what the editor produced, and record
+   * the result as a new version.
+   *
+   * Staff may edit any job that is not CLOSED. Customers may edit only their own
+   * job, and only while changes have been requested of them.
+   */
+  @Mutation(() => Job, {
+    description: "Replace a job's workflow graph from the workflow editor and record the result as a new job version."
+  })
+  async saveJobWorkflows(@Args('input', { type: () => SaveJobWorkflowsInput }) input: SaveJobWorkflowsInput, @CurrentUser() user: User): Promise<Job> {
+    const job = await this.jobService.findById(input.jobId);
+    if (!job) {
+      throw new NotFoundException(`Job with ID ${input.jobId} not found`);
+    }
+
+    const isStaff = (user.realm_access?.roles ?? []).includes(Role.DamplabStaff);
+    if (isStaff) {
+      if (job.state === JobState.CLOSED) {
+        throw new ForbiddenException('This job is closed and can no longer be edited');
+      }
+    } else if (job.sub !== user.sub) {
+      throw new ForbiddenException('You do not have permission to edit this job');
+    } else if (job.state !== JobState.CHANGES_REQUESTED) {
+      throw new ForbiddenException('This job can only be edited while changes have been requested');
+    }
+
+    const updated = await this.jobVersionService.saveWorkflows(input, {
+      role: this.authorRoleFor(user),
+      sub: user.sub,
+      name: user.preferred_username ?? user.email ?? ''
+    });
+
+    // The billing core has moved. This is a no-op on a job with no SOW, which is
+    // most jobs being edited; where there is one it flags the document stale so
+    // staff can decide whether to issue a new version for re-signature.
+    await this.syncSowServicesFromJobWorkflows(input.jobId);
+
+    await this.activityService.createEvent({
+      type: 'JOB_WORKFLOWS_EDITED',
+      message: `Workflows edited on job "${job.name}"${input.note ? `: ${input.note}` : ''}`,
+      actorDisplayName: user.preferred_username ?? user.email ?? undefined,
+      jobId: input.jobId
+    });
+
+    return updated;
   }
 
   @ResolveField()
@@ -444,5 +527,12 @@ export class JobResolver {
   @ResolveField(() => SOW, { nullable: true, description: 'SOW associated with this job' })
   async sow(@Parent() job: Job): Promise<SOW | null> {
     return this.sowService.findByJobId(job._id);
+  }
+
+  @ResolveField(() => [JobVersion], {
+    description: "Every saved version of this job's workflow graph, oldest first. Jobs submitted before versioning get a v1 synthesized from their live workflows on first read."
+  })
+  async versions(@Parent() job: Job): Promise<JobVersion[]> {
+    return this.jobVersionService.listByJob(String(job._id));
   }
 }

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -124,6 +124,20 @@ export class JobResolver {
     return (user.realm_access?.roles ?? []).includes(Role.DamplabStaff) ? JobVersionAuthorRole.STAFF : JobVersionAuthorRole.CUSTOMER;
   }
 
+  /**
+   * How a state transition reads in the version history. Only the transitions
+   * that are part of the customer/staff conversation get an entry — the internal
+   * lab pipeline (QUEUED → IN_PROGRESS → COMPLETE) is already tracked per node
+   * and would just add noise to a list about document revisions.
+   */
+  private static readonly STATE_EVENT_NOTES: Partial<Record<JobState, string>> = {
+    [JobState.CHANGES_REQUESTED]: 'Changes requested',
+    [JobState.SUBMITTED]: 'Submitted',
+    [JobState.ACCEPTED]: 'Accepted',
+    [JobState.REJECTED]: 'Rejected',
+    [JobState.CLOSED]: 'Closed'
+  };
+
   @Query(() => [Job])
   @Roles(Role.DamplabStaff)
   async jobs(): Promise<Job[]> {
@@ -432,7 +446,19 @@ export class JobResolver {
         throw new ForbiddenException('You do not have permission to change the state of this job');
       }
     }
-    return (await this.jobService.updateState(job, newState))!;
+
+    const wasResubmission = job.state === JobState.CHANGES_REQUESTED && newState === JobState.SUBMITTED;
+    const updated = (await this.jobService.updateState(job, newState))!;
+
+    // Recorded after the state actually moved, so a failed transition leaves no
+    // entry. A resubmission is called out by name: "Submitted" on the second
+    // pass would read as a duplicate of the original submission.
+    const note = wasResubmission ? 'Resubmitted' : JobResolver.STATE_EVENT_NOTES[newState];
+    if (note) {
+      await this.jobVersionService.appendStateEvent(updated, newState, { role: this.authorRoleFor(user), sub: user.sub, name: user.preferred_username ?? user.email ?? '' }, note);
+    }
+
+    return updated;
   }
 
   /**

--- a/src/job/job.service.ts
+++ b/src/job/job.service.ts
@@ -109,24 +109,12 @@ export class JobService {
       throw new NotFoundException(`Job with ID ${jobId} not found`);
     }
     if (archived) {
-      return this.jobModel
-        .findOneAndUpdate(
-          { _id: jobId },
-          { $set: { isArchived: true, archivedAt: new Date(), archivedBy: actor ?? 'unknown', archivedFromState: job.state } },
-          { new: true }
-        )
-        .exec();
+      return this.jobModel.findOneAndUpdate({ _id: jobId }, { $set: { isArchived: true, archivedAt: new Date(), archivedBy: actor ?? 'unknown', archivedFromState: job.state } }, { new: true }).exec();
     }
     // $unset, not $set-to-undefined: Mongoose strips undefined values from $set,
     // which would leave the audit fields behind and make a restored job still
     // look archived-by-someone.
-    return this.jobModel
-      .findOneAndUpdate(
-        { _id: jobId },
-        { $set: { isArchived: false }, $unset: { archivedAt: '', archivedBy: '', archivedFromState: '' } },
-        { new: true }
-      )
-      .exec();
+    return this.jobModel.findOneAndUpdate({ _id: jobId }, { $set: { isArchived: false }, $unset: { archivedAt: '', archivedBy: '', archivedFromState: '' } }, { new: true }).exec();
   }
 
   async updateState(job: Job, newState: JobState): Promise<Job | null> {

--- a/src/keycloak/keycloak.service.ts
+++ b/src/keycloak/keycloak.service.ts
@@ -115,9 +115,7 @@ export class KeycloakService {
   }
 
   private async getGroupMembers(groupId: string, first: number, max: number): Promise<KeycloakUser[]> {
-    const path = `/admin/realms/${this.realm}/groups/${groupId}/members?first=${encodeURIComponent(
-      Math.max(first ?? 0, 0)
-    )}&max=${encodeURIComponent(Math.max(max ?? 0, 0))}`;
+    const path = `/admin/realms/${this.realm}/groups/${groupId}/members?first=${encodeURIComponent(Math.max(first ?? 0, 0))}&max=${encodeURIComponent(Math.max(max ?? 0, 0))}`;
     const res = await this.fetchWithToken(path);
     if (!res.ok) {
       this.logger.warn(`Keycloak group members request failed: ${res.status} ${await res.text()}`);
@@ -138,8 +136,7 @@ export class KeycloakService {
   /** Same precedence as `JobResolver.createJob` / `AddNodeInputPipe`. */
   deriveCustomerCategoryFromGroups(groups: { name?: string; path?: string }[]): CustomerCategory | undefined {
     const claims = this.claimsFromGroupList(groups);
-    const hasGroup = (groupName: string): boolean =>
-      claims.some((entry) => entry === groupName || entry.endsWith(`/${groupName}`));
+    const hasGroup = (groupName: string): boolean => claims.some((entry) => entry === groupName || entry.endsWith(`/${groupName}`));
     if (hasGroup(Role.InternalCustomers) || hasGroup(Role.InternalCustomer)) return CustomerCategory.INTERNAL_CUSTOMERS;
     if (hasGroup(Role.ExternalCustomerAcademic)) return CustomerCategory.EXTERNAL_CUSTOMER_ACADEMIC;
     if (hasGroup(Role.ExternalCustomerMarket)) return CustomerCategory.EXTERNAL_CUSTOMER_MARKET;
@@ -159,15 +156,9 @@ export class KeycloakService {
    */
   private isDefaultExternalCustomer(groups: { name?: string }[]): boolean {
     const claims = this.claimsFromGroupList(groups);
-    const has = (n: string) => claims.some((e) => e === n || e.endsWith(`/${n}`));
+    const has = (n: string): boolean => claims.some((e) => e === n || e.endsWith(`/${n}`));
     if (!has(Role.ExternalCustomer)) return false;
-    return !(
-      has(Role.InternalCustomer) ||
-      has(Role.InternalCustomers) ||
-      has(Role.ExternalCustomerAcademic) ||
-      has(Role.ExternalCustomerMarket) ||
-      has(Role.ExternalCustomerNoSalary)
-    );
+    return !(has(Role.InternalCustomer) || has(Role.InternalCustomers) || has(Role.ExternalCustomerAcademic) || has(Role.ExternalCustomerMarket) || has(Role.ExternalCustomerNoSalary));
   }
 
   private rowFromUserAndGroups(user: KeycloakUser, groups: KeycloakGroup[]): KeycloakUserCustomerManagementRow {
@@ -297,11 +288,7 @@ export class KeycloakService {
     return this.findGroupInList(groups, groupName);
   }
 
-  async listUsersInGroupWithCustomerCategory(
-    groupName: string,
-    first: number,
-    max: number
-  ): Promise<KeycloakUserCustomerManagementRow[]> {
+  async listUsersInGroupWithCustomerCategory(groupName: string, first: number, max: number): Promise<KeycloakUserCustomerManagementRow[]> {
     if (!this.isConfigured()) return [];
     const group = await this.findGroupByName(groupName);
     if (!group) return [];
@@ -324,9 +311,7 @@ export class KeycloakService {
    */
   async listAllUsersWithCustomerCategory(first: number, max: number): Promise<KeycloakUserCustomerManagementRow[]> {
     if (!this.isConfigured()) return [];
-    const path = `/admin/realms/${this.realm}/users?first=${encodeURIComponent(
-      Math.max(first ?? 0, 0)
-    )}&max=${encodeURIComponent(Math.max(max ?? 0, 0))}`;
+    const path = `/admin/realms/${this.realm}/users?first=${encodeURIComponent(Math.max(first ?? 0, 0))}&max=${encodeURIComponent(Math.max(max ?? 0, 0))}`;
     const res = await this.fetchWithToken(path);
     if (!res.ok) {
       this.logger.warn(`Keycloak list users request failed: ${res.status} ${await res.text()}`);

--- a/src/pricing/service-pricing.util.spec.ts
+++ b/src/pricing/service-pricing.util.spec.ts
@@ -1,5 +1,5 @@
 import { DampLabService, ServicePricingMode } from '../services/models/damplab-service.model';
-import { calculateServiceCost, RUN_COUNT_PARAM_ID } from './service-pricing.util';
+import { calculateServiceCost, extractRunCount, RUN_COUNT_PARAM_ID } from './service-pricing.util';
 
 /**
  * The universal run count is injected into formData client-side under a synthetic
@@ -69,5 +69,20 @@ describe('calculateServiceCost — run count multiplier', () => {
       { id: RUN_COUNT_PARAM_ID, value: 70 }
     ];
     expect(calculateServiceCost(svc, formData)).toBe(1050);
+  });
+});
+
+describe('extractRunCount', () => {
+  it('reads the run count out of formData, the same figure getMultiplier uses', () => {
+    expect(extractRunCount([{ id: RUN_COUNT_PARAM_ID, value: 70 }])).toBe(70);
+  });
+
+  it('is undefined when no run count entry is present', () => {
+    expect(extractRunCount([{ id: 'unrelated', value: 1 }])).toBeUndefined();
+    expect(extractRunCount(undefined)).toBeUndefined();
+  });
+
+  it('reads the legacy object-keyed formData shape too', () => {
+    expect(extractRunCount({ [RUN_COUNT_PARAM_ID]: 70 })).toBe(70);
   });
 });

--- a/src/pricing/service-pricing.util.spec.ts
+++ b/src/pricing/service-pricing.util.spec.ts
@@ -1,0 +1,73 @@
+import { DampLabService, ServicePricingMode } from '../services/models/damplab-service.model';
+import { calculateServiceCost, RUN_COUNT_PARAM_ID } from './service-pricing.util';
+
+/**
+ * The universal run count is injected into formData client-side under a synthetic
+ * id and is deliberately not part of the stored service.parameters. The backend
+ * must therefore read it straight from formData, the same way the UI does, or a
+ * SOW save fails its own pricing consistency check.
+ */
+function service(overrides: Partial<DampLabService> = {}): DampLabService {
+  return {
+    price: 5,
+    pricingMode: ServicePricingMode.SERVICE,
+    parameters: [],
+    ...overrides
+  } as unknown as DampLabService;
+}
+
+describe('calculateServiceCost — run count multiplier', () => {
+  it('multiplies a SERVICE-priced service by the run count from formData', () => {
+    const formData = [{ id: RUN_COUNT_PARAM_ID, value: 70 }];
+    expect(calculateServiceCost(service(), formData)).toBe(350);
+  });
+
+  it('accepts a run count sent as a string', () => {
+    const formData = [{ id: RUN_COUNT_PARAM_ID, value: '70' }];
+    expect(calculateServiceCost(service(), formData)).toBe(350);
+  });
+
+  it('leaves the cost alone when no run count is present', () => {
+    expect(calculateServiceCost(service(), [])).toBe(5);
+  });
+
+  it('treats a run count of 1 as a no-op', () => {
+    expect(calculateServiceCost(service(), [{ id: RUN_COUNT_PARAM_ID, value: 1 }])).toBe(5);
+  });
+
+  it('ignores a zero or non-numeric run count rather than zeroing the price', () => {
+    expect(calculateServiceCost(service(), [{ id: RUN_COUNT_PARAM_ID, value: 0 }])).toBe(5);
+    expect(calculateServiceCost(service(), [{ id: RUN_COUNT_PARAM_ID, value: 'abc' }])).toBe(5);
+  });
+
+  it('multiplies PARAMETER-priced services too', () => {
+    const svc = service({
+      pricingMode: ServicePricingMode.PARAMETER,
+      parameters: [{ id: 'samples', price: 3, type: 'number' }]
+    } as Partial<DampLabService>);
+    const formData = [
+      { id: 'samples', value: 2 },
+      { id: RUN_COUNT_PARAM_ID, value: 70 }
+    ];
+    // 1 priced parameter value at $3, multiplied by 70 runs
+    expect(calculateServiceCost(svc, formData)).toBe(210);
+  });
+
+  it('does not double-count when the service also declares the run count as a multiplier', () => {
+    const svc = service({
+      parameters: [{ id: RUN_COUNT_PARAM_ID, isPriceMultiplier: true }]
+    } as Partial<DampLabService>);
+    expect(calculateServiceCost(svc, [{ id: RUN_COUNT_PARAM_ID, value: 70 }])).toBe(350);
+  });
+
+  it('still applies other isPriceMultiplier parameters alongside the run count', () => {
+    const svc = service({
+      parameters: [{ id: 'plates', isPriceMultiplier: true }]
+    } as Partial<DampLabService>);
+    const formData = [
+      { id: 'plates', value: 3 },
+      { id: RUN_COUNT_PARAM_ID, value: 70 }
+    ];
+    expect(calculateServiceCost(svc, formData)).toBe(1050);
+  });
+});

--- a/src/pricing/service-pricing.util.ts
+++ b/src/pricing/service-pricing.util.ts
@@ -147,6 +147,18 @@ function getMultiplier(parameters: unknown, rawFormData: unknown): number {
   return multiplier;
 }
 
+/**
+ * The universal run-count value for a node, if any — the same figure
+ * getMultiplier folds into cost. Exposed separately so the Fee Schedule editor
+ * can show staff what multiplier is baked into a line's total, since the
+ * total itself doesn't say.
+ */
+export function extractRunCount(rawFormData: unknown): number | undefined {
+  const formData = normalizeFormDataToArray(rawFormData, new Set());
+  const entry = formData.find((e) => e.id === RUN_COUNT_PARAM_ID);
+  return entry ? resolveQty(entry.value) : undefined;
+}
+
 export function calculateServiceCost(service: DampLabService, rawFormData: unknown, fallbackCost?: number, customerCategory?: CustomerCategory): number {
   const pricingMode = service.pricingMode ?? ServicePricingMode.SERVICE;
   let baseCost = 0;

--- a/src/pricing/service-pricing.util.ts
+++ b/src/pricing/service-pricing.util.ts
@@ -42,6 +42,14 @@ interface ServiceParameterDefinition {
 
 export type CustomerCategory = 'INTERNAL_CUSTOMERS' | 'EXTERNAL_CUSTOMER_ACADEMIC' | 'EXTERNAL_CUSTOMER_MARKET' | 'EXTERNAL_CUSTOMER_NO_SALARY';
 
+/**
+ * Id of the universal run count. The UI injects it into formData for every service
+ * rather than adding it to each service's stored parameters, so it will not appear
+ * in service.parameters and has to be read straight from formData.
+ * Must stay in sync with RUN_COUNT_PARAM_ID in damplab-ui/src/utils/servicePricing.ts.
+ */
+export const RUN_COUNT_PARAM_ID = '__runCount';
+
 function normalizePrice(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string' && value.trim() !== '') {
@@ -93,104 +101,47 @@ function resolveCategoryPrice(
   return normalizePrice(pricing?.legacy ?? input.price);
 }
 
-function calculateParameterCost(parameters: unknown, rawFormData: unknown): number {
-  if (!Array.isArray(parameters)) return 0;
-
-  const paramsById = new Map<string, ServiceParameterDefinition>();
-  for (const param of parameters as ServiceParameterDefinition[]) {
-    if (!param || typeof param !== 'object') continue;
-    const id = typeof param.id === 'string' ? param.id : undefined;
-    if (!id) continue;
-    paramsById.set(id, param);
+function resolveQty(rawValue: unknown): number | undefined {
+  if (Array.isArray(rawValue)) {
+    let sum = 0;
+    let hasAny = false;
+    for (const v of rawValue) {
+      const n = typeof v === 'number' ? v : typeof v === 'string' && v.trim() !== '' ? Number(v) : NaN;
+      if (!Number.isFinite(n)) continue;
+      hasAny = true;
+      sum += n;
+    }
+    return hasAny ? sum : undefined;
   }
-
-  const multiValueParamIds = getMultiValueParamIds(parameters);
-  const formData = normalizeFormDataToArray(rawFormData, multiValueParamIds);
-  const formDataMap = new Map(formData.map((entry) => [entry.id, entry.value]));
-
-  let total = 0;
-
-  paramsById.forEach((param, id) => {
-    const rawValue = formDataMap.get(id);
-    const isMulti = multiValueParamIds.has(id) || Array.isArray(rawValue);
-
-    const options = Array.isArray(param.options) ? param.options : undefined;
-    const hasOptionPricing =
-      typeof param.type === 'string' && (param.type === 'dropdown' || param.type === 'enum') && !!options && options.some((opt) => resolveCategoryPrice(opt, undefined) !== undefined);
-
-    // When dropdown options have prices, use option-level pricing.
-    if (hasOptionPricing && options) {
-      const valuesArray = Array.isArray(rawValue) ? rawValue : rawValue != null ? [rawValue] : [];
-
-      for (const v of valuesArray) {
-        if (v === null || v === undefined || v === '') continue;
-        const optId = String(v);
-        const opt = options.find((o) => typeof o.id === 'string' && o.id === optId);
-        if (!opt) continue;
-        const price = resolveCategoryPrice(opt, undefined);
-        if (price === undefined) continue;
-        total += price;
-      }
-
-      return;
-    }
-
-    // Fallback: parameter-level pricing using per-parameter price and count of values.
-    const unitPrice = resolveCategoryPrice(param, undefined);
-    if (unitPrice === undefined) return;
-
-    let quantity = 0;
-    if (isMulti) {
-      if (Array.isArray(rawValue)) quantity = rawValue.length;
-      else if (rawValue !== null && rawValue !== undefined) quantity = 1;
-    } else if (rawValue !== null && rawValue !== undefined) {
-      quantity = 1;
-    }
-    if (quantity === 0) return;
-
-    total += unitPrice * quantity;
-  });
-
-  return total;
+  const n = typeof rawValue === 'number' ? rawValue : typeof rawValue === 'string' && rawValue.trim() !== '' ? Number(rawValue) : NaN;
+  return Number.isFinite(n) ? n : undefined;
 }
 
 function getMultiplier(parameters: unknown, rawFormData: unknown): number {
-  if (!Array.isArray(parameters)) return 1;
-
   const multiValueParamIds = getMultiValueParamIds(parameters);
   const formData = normalizeFormDataToArray(rawFormData, multiValueParamIds);
   const formDataMap = new Map(formData.map((entry) => [entry.id, entry.value]));
 
   let multiplier = 1;
 
-  for (const param of parameters as ServiceParameterDefinition[]) {
-    if (!param || typeof param !== 'object') continue;
-    if (param.isPriceMultiplier !== true) continue;
-    const id = typeof param.id === 'string' ? param.id : undefined;
-    if (!id) continue;
+  // Universal run count, read straight from formData: the UI injects it for every
+  // service, so it is absent from service.parameters and the loop below cannot see it.
+  const runCountQty = resolveQty(formDataMap.get(RUN_COUNT_PARAM_ID));
+  if (runCountQty !== undefined) multiplier *= runCountQty;
 
-    const rawValue = formDataMap.get(id);
-    if (rawValue === null || rawValue === undefined) continue;
+  // Any further multiplier parameters the service declares for itself. The run count
+  // is skipped here so a service that also declares it is not counted twice.
+  if (Array.isArray(parameters)) {
+    for (const param of parameters as ServiceParameterDefinition[]) {
+      if (!param || typeof param !== 'object') continue;
+      if (param.isPriceMultiplier !== true) continue;
+      const id = typeof param.id === 'string' ? param.id : undefined;
+      if (!id || id === RUN_COUNT_PARAM_ID) continue;
 
-    let qty: number | undefined;
-
-    if (Array.isArray(rawValue)) {
-      let sum = 0;
-      let hasAny = false;
-      for (const v of rawValue) {
-        const n = typeof v === 'number' ? v : typeof v === 'string' && v.trim() !== '' ? Number(v) : NaN;
-        if (!Number.isFinite(n)) continue;
-        hasAny = true;
-        sum += n;
-      }
-      qty = hasAny ? sum : undefined;
-    } else {
-      const n = typeof rawValue === 'number' ? rawValue : typeof rawValue === 'string' && rawValue.trim() !== '' ? Number(rawValue) : NaN;
-      qty = Number.isFinite(n) ? n : undefined;
+      const qty = resolveQty(formDataMap.get(id));
+      if (qty === undefined) continue;
+      multiplier *= qty;
     }
-
-    if (qty === undefined) continue;
-    multiplier *= qty;
   }
 
   return multiplier;

--- a/src/protocol-map/protocol-map.module.ts
+++ b/src/protocol-map/protocol-map.module.ts
@@ -8,12 +8,7 @@ import { InventoryModule } from '../inventory/inventory.module';
 import { StationModule } from '../station/station.module';
 
 @Module({
-  imports: [
-    MongooseModule.forFeature([{ name: ProtocolStepMapping.name, schema: ProtocolStepMappingSchema }]),
-    ProtocolsModule,
-    InventoryModule,
-    StationModule
-  ],
+  imports: [MongooseModule.forFeature([{ name: ProtocolStepMapping.name, schema: ProtocolStepMappingSchema }]), ProtocolsModule, InventoryModule, StationModule],
   providers: [ProtocolMapService, ProtocolMapResolver],
   exports: [ProtocolMapService]
 })

--- a/src/protocol-map/protocol-map.resolver.ts
+++ b/src/protocol-map/protocol-map.resolver.ts
@@ -1,15 +1,8 @@
-import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
 import { ProtocolStepMapping } from './protocol-step-mapping.model';
 import { ProtocolMapService } from './protocol-map.service';
-import {
-  ResolvedEquipment,
-  ResolvedPlacement,
-  ResolvedProtocol,
-  ResolvedStep,
-  StepMappingStatus,
-  UpsertProtocolStepMappingInput
-} from './protocol-map.dto';
+import { ResolvedEquipment, ResolvedPlacement, ResolvedProtocol, ResolvedStep, StepMappingStatus, UpsertProtocolStepMappingInput } from './protocol-map.dto';
 import { ProtocolsService } from '../protocols/protocols.service';
 import { InventoryService } from '../inventory/inventory.service';
 import { StationService } from '../station/station.service';
@@ -21,7 +14,11 @@ import { User } from '../auth/user.interface';
 
 /** Strip HTML tags to a short plain-text label (drift-detection snapshot; NOT protocol content storage). */
 function toLabel(html: string, max = 120): string {
-  const text = (html || '').replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
+  const text = (html || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
   return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }
 
@@ -42,18 +39,12 @@ export class ProtocolMapResolver {
   }
 
   @Mutation(() => ProtocolStepMapping, { description: 'Create or update the mapping for one protocol step.' })
-  async upsertProtocolStepMapping(
-    @Args('input') input: UpsertProtocolStepMappingInput,
-    @CurrentUser() user: User
-  ): Promise<ProtocolStepMapping> {
+  async upsertProtocolStepMapping(@Args('input') input: UpsertProtocolStepMappingInput, @CurrentUser() user: User): Promise<ProtocolStepMapping> {
     return this.mapService.upsert(input, user?.preferred_username || user?.email);
   }
 
   @Mutation(() => Boolean, { description: 'Remove the mapping for one protocol step.' })
-  async deleteProtocolStepMapping(
-    @Args('protocolId') protocolId: string,
-    @Args('stepId') stepId: string
-  ): Promise<boolean> {
+  async deleteProtocolStepMapping(@Args('protocolId') protocolId: string, @Args('stepId') stepId: string): Promise<boolean> {
     return this.mapService.remove(protocolId, stepId);
   }
 

--- a/src/protocol-map/protocol-map.service.ts
+++ b/src/protocol-map/protocol-map.service.ts
@@ -17,9 +17,7 @@ export class ProtocolMapService {
     for (const k of ['stepNumber', 'stepTitle', 'equipmentIds', 'requiresNoEquipment', 'paramTags', 'reviewed'] as const) {
       if (input[k] !== undefined) set[k] = input[k] as unknown;
     }
-    return (await this.model
-      .findOneAndUpdate({ protocolId: input.protocolId, stepId: input.stepId }, { $set: set }, { upsert: true, new: true, setDefaultsOnInsert: true })
-      .exec())!;
+    return (await this.model.findOneAndUpdate({ protocolId: input.protocolId, stepId: input.stepId }, { $set: set }, { upsert: true, new: true, setDefaultsOnInsert: true }).exec())!;
   }
 
   async findByProtocol(protocolId: string): Promise<ProtocolStepMapping[]> {

--- a/src/protocols/protocols.service.ts
+++ b/src/protocols/protocols.service.ts
@@ -146,9 +146,7 @@ export class ProtocolsService {
       }
     }
 
-    const url =
-      (typeof p.url === 'string' && p.url) ||
-      (typeof p.uri === 'string' ? `https://www.protocols.io/view/${p.uri}` : `https://www.protocols.io/view/${idOrSlug}`);
+    const url = (typeof p.url === 'string' && p.url) || (typeof p.uri === 'string' ? `https://www.protocols.io/view/${p.uri}` : `https://www.protocols.io/view/${idOrSlug}`);
 
     return {
       id: String(numericId ?? idOrSlug),

--- a/src/services/damplab-services.services.ts
+++ b/src/services/damplab-services.services.ts
@@ -91,9 +91,7 @@ export class DampLabServices {
       return;
     }
     // Drop blanks/dupes while preserving admin-specified order.
-    service.protocolIds = service.protocolIds
-      .map((p) => (typeof p === 'string' ? p.trim() : ''))
-      .filter((p, i, arr) => p && arr.indexOf(p) === i);
+    service.protocolIds = service.protocolIds.map((p) => (typeof p === 'string' ? p.trim() : '')).filter((p, i, arr) => p && arr.indexOf(p) === i);
   }
 
   /** Active services only (for admin catalog, canvas palette, bundles, categories, allowedConnections). */
@@ -107,12 +105,8 @@ export class DampLabServices {
    */
   async findByIds(ids: mongoose.Types.ObjectId[]): Promise<DampLabService[]> {
     const services = await this.dampLabServiceModel.find({ _id: { $in: ids }, isDeleted: { $ne: true } }).exec();
-    const serviceById = new Map(
-      services.map((service) => [String(service._id), this.normalizeService(service)] as const)
-    );
-    return ids
-      .map((id) => serviceById.get(String(id)))
-      .filter((service): service is DampLabService => Boolean(service));
+    const serviceById = new Map(services.map((service) => [String(service._id), this.normalizeService(service)] as const));
+    return ids.map((id) => serviceById.get(String(id))).filter((service): service is DampLabService => Boolean(service));
   }
 
   /**

--- a/src/services/models/damplab-service.model.ts
+++ b/src/services/models/damplab-service.model.ts
@@ -142,6 +142,15 @@ export class DampLabService {
   })
   pricingMode?: ServicePricingMode;
 
+  @Prop({ default: false })
+  @Field(() => Boolean, {
+    nullable: true,
+    defaultValue: false,
+    description:
+      'When true, a canvas node for this service offers a "Number of runs" count, and its price is multiplied by it. Off by default: most operations run once, and an always-present run count is noise on every node. Affects only what the editor offers going forward — a run count already stored on a submitted job keeps pricing and displaying either way, so turning this off never silently reprices history.'
+  })
+  allowMultipleRuns?: boolean;
+
   @Prop({ type: [String], required: false, default: [] })
   @Field(() => [String], {
     description: 'Array of deliverable descriptions for this service',

--- a/src/sow/dto/create-sow.input.ts
+++ b/src/sow/dto/create-sow.input.ts
@@ -134,8 +134,8 @@ export class CreateSOWInput {
   @Field(() => SOWPricingInput, { description: 'Pricing information' })
   pricing: SOWPricingInput;
 
-  @Field({ description: 'Terms and conditions' })
-  terms: string;
+  @Field({ description: 'Legacy free-text terms. The live document text lives on the SOW version; new SOWs need not send this.', nullable: true })
+  terms?: string;
 
   @Field({ description: 'Additional information', nullable: true })
   additionalInformation?: string;

--- a/src/sow/dto/save-sow-version.input.ts
+++ b/src/sow/dto/save-sow-version.input.ts
@@ -14,6 +14,9 @@ export class SowFieldInput {
 
   @Field({ nullable: true, defaultValue: true, description: 'False hides the section from the customer, the PDF and consent, without discarding its text' })
   isEnabled?: boolean;
+
+  @Field({ nullable: true, defaultValue: false, description: 'Staff flag: when true, the customer must type their initials for this section before they can sign' })
+  requiresInitials?: boolean;
 }
 
 @InputType()

--- a/src/sow/dto/save-sow-version.input.ts
+++ b/src/sow/dto/save-sow-version.input.ts
@@ -33,6 +33,12 @@ export class SaveSowVersionInput {
   @Field(() => SowInputsInput)
   inputs: SowInputsInput;
 
-  @Field({ nullable: true, description: 'Optional note describing what changed, shown in the version history' })
-  note?: string;
+  /**
+   * Required on the way in, while `SowVersion.note` stays optional on the way
+   * out — versions saved before this was enforced have none, and the canned
+   * event versions (sent / signed / countersigned / cancelled) are written
+   * through appendVersion rather than this input.
+   */
+  @Field({ description: 'Note describing what changed, shown in the version history. Required.' })
+  note: string;
 }

--- a/src/sow/dto/save-sow-version.input.ts
+++ b/src/sow/dto/save-sow-version.input.ts
@@ -1,0 +1,35 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { SowInputsInput } from './sow-inputs.input';
+
+@InputType()
+export class SowFieldInput {
+  @Field({ description: 'Catalogue key, or "custom-<uuid>" for a staff-added section' })
+  key: string;
+
+  @Field({ nullable: true, description: 'Only honoured for custom sections; catalogue labels are fixed' })
+  label?: string;
+
+  @Field({ nullable: true, defaultValue: '' })
+  value?: string;
+
+  @Field({ nullable: true, defaultValue: true, description: 'False hides the section from the customer, the PDF and consent, without discarding its text' })
+  isEnabled?: boolean;
+}
+
+@InputType()
+export class SaveSowVersionInput {
+  @Field(() => Int, {
+    description:
+      'The version the editor loaded. If the SOW has moved on since, the save is rejected rather than silently overwriting a colleague — see the conflict handling in SowVersionService.saveVersion.'
+  })
+  baseVersionNumber: number;
+
+  @Field(() => [SowFieldInput])
+  fields: SowFieldInput[];
+
+  @Field(() => SowInputsInput)
+  inputs: SowInputsInput;
+
+  @Field({ nullable: true, description: 'Optional note describing what changed, shown in the version history' })
+  note?: string;
+}

--- a/src/sow/dto/sign-sow.input.ts
+++ b/src/sow/dto/sign-sow.input.ts
@@ -2,6 +2,15 @@ import { Field, InputType, Int } from '@nestjs/graphql';
 import { SowFieldKind } from '../sow-version.model';
 
 @InputType()
+export class SectionInitialsInput {
+  @Field({ description: 'Key of the section being initialled' })
+  key: string;
+
+  @Field({ description: 'Initials as typed by the signer' })
+  initials: string;
+}
+
+@InputType()
 export class SignSowInput {
   @Field(() => Int, { description: 'Version the signer is looking at. Rejected if it is no longer the one in force, so nobody signs a superseded document.' })
   versionNumber: number;
@@ -13,4 +22,10 @@ export class SignSowInput {
     description: 'Which groups of sections the signer ticked: the calculated figures, the standard prose, and any custom sections. Every group present in the document must be acknowledged.'
   })
   consentedGroups: SowFieldKind[];
+
+  @Field(() => [SectionInitialsInput], {
+    nullable: true,
+    description: 'Initials for every section staff flagged requiresInitials. Every such section that is enabled in the document must be present with non-empty initials.'
+  })
+  sectionInitials?: SectionInitialsInput[];
 }

--- a/src/sow/dto/sign-sow.input.ts
+++ b/src/sow/dto/sign-sow.input.ts
@@ -1,0 +1,16 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { SowFieldKind } from '../sow-version.model';
+
+@InputType()
+export class SignSowInput {
+  @Field(() => Int, { description: 'Version the signer is looking at. Rejected if it is no longer the one in force, so nobody signs a superseded document.' })
+  versionNumber: number;
+
+  @Field({ description: 'Typed full name, which is the signature under the new flow' })
+  name: string;
+
+  @Field(() => [SowFieldKind], {
+    description: 'Which groups of sections the signer ticked: the calculated figures, the standard prose, and any custom sections. Every group present in the document must be acknowledged.'
+  })
+  consentedGroups: SowFieldKind[];
+}

--- a/src/sow/dto/sow-inputs.input.ts
+++ b/src/sow/dto/sow-inputs.input.ts
@@ -1,0 +1,79 @@
+import { Field, InputType, Int, Float, ID } from '@nestjs/graphql';
+import { SOWAdjustmentType } from '../sow.model';
+
+/**
+ * The structured drivers behind the calculated sections, as sent by the editor.
+ * Mirrors SowVersionInputs; kept as a separate input type so the write surface
+ * cannot be widened just by adding a field to the stored model.
+ */
+
+@InputType()
+export class SowPeriodInput {
+  @Field({ description: 'Start of this period. May be in the past — retroactive SOWs are legitimate.' })
+  startDate: Date;
+
+  @Field(() => Int, { description: 'Length in days, inclusive of the start date' })
+  durationDays: number;
+
+  @Field({ nullable: true, description: 'Optional name, e.g. "Phase 1"' })
+  label?: string;
+}
+
+@InputType()
+export class SowVersionServiceInput {
+  @Field(() => ID)
+  serviceId: string;
+
+  @Field()
+  name: string;
+
+  @Field({ nullable: true, defaultValue: '' })
+  description?: string;
+
+  @Field(() => Float, { description: 'Cost for this line. A staff override here writes through to the billing core invoices read.' })
+  cost: number;
+}
+
+@InputType()
+export class SowVersionAdjustmentInput {
+  @Field(() => SOWAdjustmentType, {
+    description: 'DISCOUNT subtracts, ADDITIONAL_COST adds. SPECIAL_TERM is no longer accepted — it never affected a total; use a custom section for narrative terms.'
+  })
+  type: SOWAdjustmentType;
+
+  @Field()
+  description: string;
+
+  @Field(() => Float)
+  amount: number;
+
+  @Field({ nullable: true })
+  reason?: string;
+}
+
+@InputType()
+export class SowInputsInput {
+  @Field({ nullable: true, defaultValue: '' })
+  projectManager?: string;
+
+  @Field({ nullable: true, defaultValue: '' })
+  projectLead?: string;
+
+  @Field(() => [SowPeriodInput], { nullable: true, defaultValue: [] })
+  periods?: SowPeriodInput[];
+
+  @Field({ nullable: true })
+  sowTitle?: string;
+
+  @Field(() => [String], { nullable: true, defaultValue: [] })
+  scopeOfWork?: string[];
+
+  @Field(() => [String], { nullable: true, defaultValue: [] })
+  deliverables?: string[];
+
+  @Field(() => [SowVersionServiceInput], { nullable: true, defaultValue: [] })
+  services?: SowVersionServiceInput[];
+
+  @Field(() => [SowVersionAdjustmentInput], { nullable: true, defaultValue: [] })
+  adjustments?: SowVersionAdjustmentInput[];
+}

--- a/src/sow/dto/update-sow.input.ts
+++ b/src/sow/dto/update-sow.input.ts
@@ -1,5 +1,5 @@
 import { InputType, Field, Float } from '@nestjs/graphql';
-import { SOWTimelineInput, SOWResourcesInput, SOWPricingInput, SOWServiceInput, SOWPricingAdjustmentInput, SOWDiscountInput } from './create-sow.input';
+import { SOWServiceInput, SOWPricingAdjustmentInput, SOWDiscountInput } from './create-sow.input';
 import { SOWStatus } from '../sow.model';
 
 @InputType()

--- a/src/sow/migrate-sows.ts
+++ b/src/sow/migrate-sows.ts
@@ -1,0 +1,214 @@
+/**
+ * One-shot migration: give every pre-versioning SOW a version 1.
+ *
+ * Run with:
+ *   npm run migrate:sows            # apply
+ *   npm run migrate:sows -- --dry   # report only
+ *
+ * Lives in the backend package rather than scripts/ on purpose. It imports the
+ * same buildCalculatedFields and deriveInputs the server uses, so a migrated
+ * document is byte-identical to one the running app would produce. The scripts/
+ * CLI is a separate package on the raw mongo driver, which would have meant a
+ * second copy of the calculator — the exact duplication this feature exists to
+ * remove.
+ *
+ * Idempotent: a SOW that already has any version is skipped, so it is safe to
+ * re-run after a partial failure.
+ */
+import { randomUUID } from 'node:crypto';
+import mongoose from 'mongoose';
+import { SOW, SOWStatus, SOWAdjustmentType } from './sow.model';
+import { SowField, SowFieldKind, SowConsent } from './sow-version.model';
+import { SowVersionService } from './sow-version.service';
+import { buildCalculatedFields } from './sow-field-calculator';
+import { CUSTOM_FIELD_ORDER_BASE, SOW_PROSE_DEFAULTS } from './sow-field-defaults';
+
+interface MigrationReport {
+  scanned: number;
+  migrated: number;
+  skipped: number;
+  failed: Array<{ sowId: string; error: string }>;
+}
+
+/** Statuses that mean the customer has already been shown this document. */
+const ISSUED_STATUSES = new Set<SOWStatus>([SOWStatus.SENT, SOWStatus.SIGNED, SOWStatus.FINAL, SOWStatus.CANCELLED]);
+
+/**
+ * Builds version 1's fields from a legacy SOW.
+ *
+ * Most sections regenerate exactly, because the inputs are derived from the same
+ * SOW. Two need carrying by hand:
+ *   - additionalInformation, free text that has no generated equivalent
+ *   - SPECIAL_TERM adjustments, which are being removed as an adjustment type;
+ *     their wording survives as custom sections so nothing staff wrote is lost
+ */
+export function buildLegacyFields(sow: SOW, job: { customerCategory?: string; jobId?: string; name?: string } | null): SowField[] {
+  const inputs = SowVersionService.deriveInputs(sow, job);
+  const ctx = SowVersionService.buildContext(sow, job);
+  const fields = buildCalculatedFields(inputs, ctx);
+
+  const additional = (sow.additionalInformation ?? '').trim();
+  if (additional) {
+    const target = fields.find((f) => f.key === 'additionalInformation');
+    if (target) {
+      target.value = additional;
+      target.isOverridden = additional !== (SOW_PROSE_DEFAULTS.additionalInformation ?? '');
+      target.isEnabled = true;
+    }
+  }
+
+  const specialTerms = (sow.pricing?.adjustments ?? []).filter((a) => a.type === SOWAdjustmentType.SPECIAL_TERM);
+  specialTerms.forEach((term, i) => {
+    const desc = (term.description ?? '').trim();
+    const reason = (term.reason ?? '').trim();
+    const body = [desc, reason].filter(Boolean).join(' — ');
+    if (!body) return;
+    fields.push({
+      key: `custom-${randomUUID()}`,
+      label: 'Special Term',
+      kind: SowFieldKind.CUSTOM,
+      order: CUSTOM_FIELD_ORDER_BASE + i,
+      value: body,
+      calculatedValue: undefined,
+      isOverridden: false,
+      isEnabled: true,
+      allowsTextOverride: true
+    });
+  });
+
+  return fields.sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Carries a legacy signature onto the version, including the drawn image.
+ * Without the image, re-exporting a migrated SOW would produce a PDF missing the
+ * signature the customer actually drew — a regression on a signed document.
+ */
+export function toConsent(signature: { name?: string; signedAt?: string; signatureDataUrl?: string } | undefined | null): SowConsent | undefined {
+  if (!signature?.name?.trim()) return undefined;
+  const parsed = signature.signedAt ? new Date(signature.signedAt) : new Date();
+  return {
+    name: signature.name.trim(),
+    signedAt: Number.isNaN(parsed.getTime()) ? new Date() : parsed,
+    // Legacy signatures predate per-group consent; the signer assented to the
+    // whole document, so record that rather than inventing a narrower claim.
+    consentedGroups: [SowFieldKind.CALCULATED, SowFieldKind.PROSE, SowFieldKind.CUSTOM],
+    legacySignatureDataUrl: signature.signatureDataUrl
+  };
+}
+
+export async function migrateSows(db: mongoose.mongo.Db, opts: { dryRun?: boolean; log?: (msg: string) => void } = {}): Promise<MigrationReport> {
+  const log = opts.log ?? console.log;
+  const sows = db.collection('sows');
+  const versions = db.collection('sow_versions');
+  const jobs = db.collection('jobs');
+
+  const report: MigrationReport = { scanned: 0, migrated: 0, skipped: 0, failed: [] };
+  const cursor = sows.find({});
+
+  for await (const raw of cursor) {
+    report.scanned += 1;
+    const sowId = String(raw._id);
+
+    try {
+      const already = await versions.findOne({ sowId });
+      if (already) {
+        report.skipped += 1;
+        continue;
+      }
+
+      const job = raw.jobId ? await jobs.findOne({ _id: new mongoose.Types.ObjectId(String(raw.jobId)) }).catch(() => null) : null;
+      const sow = raw as unknown as SOW;
+
+      const fields = buildLegacyFields(sow, job as any);
+      const inputs = SowVersionService.deriveInputs(sow, job as any);
+      const status: SOWStatus = (raw.status as SOWStatus) ?? SOWStatus.DRAFT;
+      const visibleToCustomer = ISSUED_STATUSES.has(status);
+
+      const clientSignature = toConsent(raw.clientSignature);
+      const staffSignature = toConsent(raw.technicianSignature);
+
+      if (opts.dryRun) {
+        log(
+          `[dry] ${raw.sowNumber ?? sowId}: status=${status} visible=${visibleToCustomer} fields=${fields.length} customFromSpecialTerms=${fields.filter((f) => f.kind === SowFieldKind.CUSTOM).length}`
+        );
+        report.migrated += 1;
+        continue;
+      }
+
+      await versions.insertOne({
+        sow: new mongoose.Types.ObjectId(sowId),
+        sowId,
+        versionNumber: 1,
+        fields,
+        inputs,
+        status,
+        visibleToCustomer,
+        sentToCustomerAt: visibleToCustomer ? raw.updatedAt ?? raw.createdAt ?? new Date() : undefined,
+        clientSignature,
+        staffSignature,
+        note: 'Migrated from the pre-versioning SOW flow',
+        isDiscarded: false,
+        createdBy: raw.createdBy ?? 'migration',
+        createdByName: raw.createdBy ?? 'migration',
+        createdAt: raw.createdAt ?? new Date()
+      });
+
+      await sows.updateOne(
+        { _id: raw._id },
+        {
+          $set: {
+            currentVersionNumber: 1,
+            activeVersionNumber: visibleToCustomer ? 1 : 0,
+            documentStale: false,
+            questions: raw.questions ?? []
+          }
+        }
+      );
+
+      report.migrated += 1;
+      log(`migrated ${raw.sowNumber ?? sowId} (${status})`);
+    } catch (error) {
+      report.failed.push({ sowId, error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  return report;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry') || process.argv.includes('--dry-run');
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is not set. Run with: node --env-file=.env dist/src/sow/migrate-sows.js');
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  try {
+    const db = mongoose.connection.db;
+    if (!db) throw new Error('No database handle after connect');
+
+    console.log(dryRun ? 'Dry run — no writes will be made.' : 'Migrating SOWs...');
+    const report = await migrateSows(db, { dryRun });
+
+    console.log('\n--- SOW migration ---');
+    console.log(`scanned : ${report.scanned}`);
+    console.log(`migrated: ${report.migrated}${dryRun ? ' (would be)' : ''}`);
+    console.log(`skipped : ${report.skipped} (already versioned)`);
+    console.log(`failed  : ${report.failed.length}`);
+    for (const f of report.failed) console.error(`  ${f.sowId}: ${f.error}`);
+
+    if (report.failed.length > 0) process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+// Only run when executed directly, so the functions above stay unit-testable.
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/sow/migrate-sows.ts
+++ b/src/sow/migrate-sows.ts
@@ -72,7 +72,9 @@ export function buildLegacyFields(sow: SOW, job: { customerCategory?: string; jo
       calculatedValue: undefined,
       isOverridden: false,
       isEnabled: true,
-      allowsTextOverride: true
+      allowsTextOverride: true,
+      allowsEmpty: true,
+      requiresInitials: false
     });
   });
 
@@ -93,6 +95,7 @@ export function toConsent(signature: { name?: string; signedAt?: string; signatu
     // Legacy signatures predate per-group consent; the signer assented to the
     // whole document, so record that rather than inventing a narrower claim.
     consentedGroups: [SowFieldKind.CALCULATED, SowFieldKind.PROSE, SowFieldKind.CUSTOM],
+    sectionInitials: [],
     legacySignatureDataUrl: signature.signatureDataUrl
   };
 }
@@ -127,6 +130,9 @@ export async function migrateSows(db: mongoose.mongo.Db, opts: { dryRun?: boolea
 
       const clientSignature = toConsent(raw.clientSignature);
       const staffSignature = toConsent(raw.technicianSignature);
+      // A migrated SOW already issued under the old flow counts as its own
+      // send, same rule createInitialVersion applies going forward.
+      const versionNumber = SowVersionService.encodeVersionNumber(visibleToCustomer ? 1 : 0, visibleToCustomer ? 0 : 1);
 
       if (opts.dryRun) {
         log(
@@ -139,7 +145,7 @@ export async function migrateSows(db: mongoose.mongo.Db, opts: { dryRun?: boolea
       await versions.insertOne({
         sow: new mongoose.Types.ObjectId(sowId),
         sowId,
-        versionNumber: 1,
+        versionNumber,
         fields,
         inputs,
         status,
@@ -158,10 +164,9 @@ export async function migrateSows(db: mongoose.mongo.Db, opts: { dryRun?: boolea
         { _id: raw._id },
         {
           $set: {
-            currentVersionNumber: 1,
-            activeVersionNumber: visibleToCustomer ? 1 : 0,
-            documentStale: false,
-            questions: raw.questions ?? []
+            currentVersionNumber: versionNumber,
+            activeVersionNumber: visibleToCustomer ? versionNumber : 0,
+            documentStale: false
           }
         }
       );

--- a/src/sow/sow-access.spec.ts
+++ b/src/sow/sow-access.spec.ts
@@ -1,0 +1,58 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Role } from '../auth/roles/roles.enum';
+import { User } from '../auth/user.interface';
+import { assertCanReadSow, canReadSow, isJobOwner } from './sow-access';
+
+function user(overrides: Partial<User> = {}): User {
+  return {
+    preferred_username: 'someone',
+    sub: 'sub-stranger',
+    email: 'stranger@example.com',
+    realm_access: { roles: [] },
+    ...overrides
+  } as User;
+}
+
+const staff = user({ sub: 'sub-staff', email: 'tech@bu.edu', realm_access: { roles: [Role.DamplabStaff] } });
+const owner = user({ sub: 'sub-owner', email: 'client@lab.org' });
+const job = { sub: 'sub-owner', email: 'client@lab.org' };
+
+describe('SOW read access', () => {
+  it('allows staff to read any SOW', () => {
+    expect(canReadSow(job, staff)).toBe(true);
+  });
+
+  it('allows the job owner, matching on sub', () => {
+    expect(canReadSow(job, user({ sub: 'sub-owner', email: 'changed@elsewhere.com' }))).toBe(true);
+  });
+
+  it('allows the job owner, matching on email', () => {
+    expect(canReadSow(job, user({ sub: 'different-sub', email: 'client@lab.org' }))).toBe(true);
+  });
+
+  it('denies an unrelated authenticated customer', () => {
+    expect(canReadSow(job, user())).toBe(false);
+    expect(() => assertCanReadSow(job, user())).toThrow(ForbiddenException);
+  });
+
+  it('denies when there is no user at all', () => {
+    expect(canReadSow(job, undefined)).toBe(false);
+  });
+
+  it('allows read-only API-key callers, which carry no roles and match no owner', () => {
+    // AuthRolesGuard has already verified the key and rejected any mutation.
+    const apiKeyCaller = user({ sub: 'apikey:abc', realm_access: { roles: [] }, apiKey: true });
+    expect(canReadSow(job, apiKeyCaller)).toBe(true);
+  });
+
+  it('does not treat missing identifiers on both sides as a match', () => {
+    expect(isJobOwner({}, user({ sub: undefined as any, email: undefined as any }))).toBe(false);
+    expect(isJobOwner({ sub: '', email: '' }, user({ sub: '', email: '' }))).toBe(false);
+  });
+
+  it('denies when the job cannot be found', () => {
+    expect(canReadSow(null, owner)).toBe(false);
+    // ...but staff still get through, so a dangling jobId is not a lockout for them.
+    expect(canReadSow(null, staff)).toBe(true);
+  });
+});

--- a/src/sow/sow-access.ts
+++ b/src/sow/sow-access.ts
@@ -1,0 +1,73 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Role } from '../auth/roles/roles.enum';
+import { User } from '../auth/user.interface';
+
+/**
+ * Who may read a given SOW.
+ *
+ * A SOW carries the client's name, email, institution, pricing and signature, so
+ * reads are restricted to DampLab staff, the customer who owns the underlying job,
+ * and trusted external systems authenticating with an API key.
+ *
+ * Ownership matches on email or sub, the same pair SOWService.submitSignature uses
+ * to decide who may sign. Keeping the two definitions identical matters: a customer
+ * who can sign a SOW must also be able to read it.
+ */
+
+export function isStaff(user: User | undefined): boolean {
+  return (user?.realm_access?.roles ?? []).includes(Role.DamplabStaff);
+}
+
+export function isJobOwner(job: { email?: string; sub?: string } | null | undefined, user: User | undefined): boolean {
+  if (!job || !user) return false;
+  // Guard against a job with no owner fields matching a user with none either.
+  if (job.sub && user.sub && job.sub === user.sub) return true;
+  if (job.email && user.email && job.email === user.email) return true;
+  return false;
+}
+
+/**
+ * API-key callers are external systems granted read-only GraphQL access; the key
+ * itself is the authorization (see AuthRolesGuard.authorizeApiKey), so they carry
+ * no roles and match no owner. Without this they would lose SOW read access.
+ */
+export function isApiKeyCaller(user: User | undefined): boolean {
+  return user?.apiKey === true;
+}
+
+export function canReadSow(job: { email?: string; sub?: string } | null | undefined, user: User | undefined): boolean {
+  return isStaff(user) || isApiKeyCaller(user) || isJobOwner(job, user);
+}
+
+export function assertCanReadSow(job: { email?: string; sub?: string } | null | undefined, user: User | undefined): void {
+  if (!canReadSow(job, user)) {
+    throw new ForbiddenException('You do not have permission to view this SOW');
+  }
+}
+
+/**
+ * Whether the caller sees the full version history or only what was issued.
+ *
+ * Staff see every version, including unsent drafts — that is the point of being
+ * able to iterate before sending. Everyone else, including API-key callers, sees
+ * only versions marked visibleToCustomer, so internal drafting never leaks.
+ */
+export function canSeeAllVersions(user: User | undefined): boolean {
+  return isStaff(user);
+}
+
+export function assertStaff(user: User | undefined, action = 'perform this action'): void {
+  if (!isStaff(user)) {
+    throw new ForbiddenException(`Only DampLab staff can ${action}`);
+  }
+}
+
+/**
+ * Signing is the one action reserved for the customer: it records their assent,
+ * so staff must not be able to produce it on their behalf.
+ */
+export function assertJobOwner(job: { email?: string; sub?: string } | null | undefined, user: User | undefined): void {
+  if (!isJobOwner(job, user)) {
+    throw new ForbiddenException('Only the customer who owns this job can sign its SOW');
+  }
+}

--- a/src/sow/sow-apply-document-billing.spec.ts
+++ b/src/sow/sow-apply-document-billing.spec.ts
@@ -1,0 +1,116 @@
+import { SOWService } from './sow.service';
+
+/**
+ * Writing the Fee Schedule's edited costs back to the billing core.
+ *
+ * The bug this guards against: a job can use the same catalogue service more
+ * than once (two PCR steps at different run counts, say). Costs used to be
+ * matched by serviceId, so saving collapsed every line sharing that id onto
+ * whichever cost came last in the request — a 70-run line silently became a
+ * 1-run line's price. See sow-version.service.spec.ts / servicePricing.ts for
+ * where the run-count multiplier itself is computed; this only covers whether
+ * an already-computed cost lands on the right line when saved.
+ */
+
+interface Harness {
+  service: SOWService;
+  sowDoc: any;
+}
+
+function harness(services: Array<{ serviceId: string; name?: string; cost: number }>): Harness {
+  const sowDoc: any = {
+    services: services.map((s) => ({ serviceId: s.serviceId, name: s.name ?? s.serviceId, description: '', cost: s.cost })),
+    pricing: { adjustments: [] }
+  };
+
+  const sowModel: any = {
+    findById: () => ({ exec: async () => sowDoc }),
+    findByIdAndUpdate: (_id: string, update: any): { exec: () => Promise<any> } => ({
+      exec: async (): Promise<any> => {
+        sowDoc.services = update.$set.services;
+        sowDoc.pricing = update.$set.pricing;
+        return sowDoc;
+      }
+    })
+  };
+
+  const service = new SOWService(sowModel, {} as any, {} as any, {} as any);
+  return { service, sowDoc };
+}
+
+describe('applyDocumentBilling', () => {
+  it('keeps each line at its own cost when the same service appears twice', async () => {
+    const { service, sowDoc } = harness([
+      { serviceId: 'pcr', cost: 350 }, // 70 runs
+      { serviceId: 'pcr', cost: 5 } // 1 run
+    ]);
+
+    await service.applyDocumentBilling('sow-1', {
+      serviceCosts: [
+        { serviceId: 'pcr', cost: 350 },
+        { serviceId: 'pcr', cost: 5 }
+      ]
+    });
+
+    expect(sowDoc.services[0].cost).toBe(350);
+    expect(sowDoc.services[1].cost).toBe(5);
+  });
+
+  it('applies an edited cost to the line it was edited on', async () => {
+    const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 100 }]);
+
+    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', cost: 275 }] });
+
+    expect(sowDoc.services[0].cost).toBe(275);
+  });
+
+  it('leaves every line unchanged if the request has a different number of lines than the SOW', async () => {
+    const { service, sowDoc } = harness([
+      { serviceId: 'pcr', cost: 350 },
+      { serviceId: 'gel', cost: 20 }
+    ]);
+
+    // Simulates a workflow sync having changed the SOW's lines while the
+    // editor was still open with its old, now-shorter set.
+    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', cost: 999 }] });
+
+    expect(sowDoc.services[0].cost).toBe(350);
+    expect(sowDoc.services[1].cost).toBe(20);
+  });
+
+  it('leaves a line unchanged if its position no longer matches the serviceId it was saved for', async () => {
+    const { service, sowDoc } = harness([
+      { serviceId: 'pcr', cost: 350 },
+      { serviceId: 'gel', cost: 20 }
+    ]);
+
+    // Same length, but the order the client remembers no longer lines up —
+    // must not silently apply "gel"'s edit onto the "pcr" line.
+    await service.applyDocumentBilling('sow-1', {
+      serviceCosts: [
+        { serviceId: 'gel', cost: 999 },
+        { serviceId: 'pcr', cost: 888 }
+      ]
+    });
+
+    expect(sowDoc.services[0].cost).toBe(350);
+    expect(sowDoc.services[1].cost).toBe(20);
+  });
+
+  it('recomputes baseCost and totalCost from the applied costs', async () => {
+    const { service } = harness([
+      { serviceId: 'pcr', cost: 350 },
+      { serviceId: 'pcr', cost: 5 }
+    ]);
+
+    const updated = await service.applyDocumentBilling('sow-1', {
+      serviceCosts: [
+        { serviceId: 'pcr', cost: 350 },
+        { serviceId: 'pcr', cost: 5 }
+      ]
+    });
+
+    expect(updated.pricing.baseCost).toBe(355);
+    expect(updated.pricing.totalCost).toBe(355);
+  });
+});

--- a/src/sow/sow-create-for-job.spec.ts
+++ b/src/sow/sow-create-for-job.spec.ts
@@ -1,0 +1,176 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { SOWService } from './sow.service';
+import { CreateSOWInput } from './dto/create-sow.input';
+
+/**
+ * Generating the first SOW for a job.
+ *
+ * This is the path behind "Generate SOW". The failures it guards against are the
+ * ones that turn a button click into a raw exception: a job whose services carry
+ * no deliverables, a job with nothing on it at all, and a second click arriving
+ * before the first has finished.
+ */
+
+interface Harness {
+  service: SOWService;
+  created: CreateSOWInput[];
+}
+
+function harness(opts: { existingSow?: unknown; job?: unknown; deliverablesById?: Record<string, string[]> } = {}): Harness {
+  const created: CreateSOWInput[] = [];
+
+  const sowModel: any = {
+    findOne: () => ({ exec: async () => opts.existingSow ?? null })
+  };
+
+  const dampLabServices: any = {
+    findOne: async (id: string) => ({ deliverables: opts.deliverablesById?.[id] ?? [] })
+  };
+
+  const jobService: any = {
+    findById: async () => (opts.job === undefined ? { _id: 'job1', name: 'Job', username: 'jdoe', email: 'j@bu.edu', institute: 'BU' } : opts.job)
+  };
+
+  const service = new SOWService(sowModel, dampLabServices, jobService, {} as any);
+  // `create` is covered by its own tests; here we only care what it is handed.
+  (service as any).create = async (input: CreateSOWInput): Promise<unknown> => {
+    created.push(input);
+    return { _id: 'sow1', ...input };
+  };
+
+  return { service, created };
+}
+
+function serviceInput(over: Partial<CreateSOWInput['services'][number]> = {}): CreateSOWInput['services'][number] {
+  return { id: 'svc-a', name: 'PCR', description: 'PCR', cost: 5, category: 'molecular-biology', formData: [], ...over } as any;
+}
+
+describe('createForJob', () => {
+  it('returns the SOW the job already has instead of failing', async () => {
+    const { service, created } = harness({ existingSow: { _id: 'existing', sowNumber: 'SOW 00004' } });
+
+    const result = await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    expect((result as any)._id).toBe('existing');
+    // A second click must not attempt a create that the unique job index rejects.
+    expect(created).toHaveLength(0);
+  });
+
+  it('rejects a job with no services in words a staff member can act on', async () => {
+    const { service } = harness();
+
+    await expect(service.createForJob('job1', [], 'tech@bu.edu')).rejects.toThrow(BadRequestException);
+    await expect(service.createForJob('job1', [], 'tech@bu.edu')).rejects.toThrow(/Add a workflow to the job first/);
+  });
+
+  it('fails clearly when the job does not exist', async () => {
+    const { service } = harness({ job: null });
+
+    await expect(service.createForJob('missing', [serviceInput()], 'tech@bu.edu')).rejects.toThrow(NotFoundException);
+  });
+
+  it('carries each line item through untouched, formData included', async () => {
+    const { service, created } = harness();
+    // The multiplier is read from formData downstream; losing it here reprices a
+    // 70-run job as a single run, which is the bug this whole flow started with.
+    const services = [serviceInput({ formData: [{ id: '__runCount', value: 70 }] })];
+
+    await service.createForJob('job1', services, 'tech@bu.edu');
+
+    expect(created[0].services).toEqual(services);
+  });
+
+  it('leaves pricing figures to the server rather than asserting its own', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    // Supplying baseCost/totalCost here would re-enter the consistency check that
+    // has no independent figure to offer — let `create` compute both.
+    expect(created[0].pricing.baseCost).toBeUndefined();
+    expect(created[0].pricing.totalCost).toBeUndefined();
+    expect(created[0].pricing.adjustments).toEqual([]);
+  });
+
+  it('names the client from the job, preferring the checkout display name', async () => {
+    const { service, created } = harness({
+      job: { _id: 'job1', name: 'Project X', clientDisplayName: 'Dr. Jane Rivera', username: 'jrivera', email: 'jane@bu.edu', institute: 'Boston University' }
+    });
+
+    await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    expect(created[0].clientName).toBe('Dr. Jane Rivera');
+    expect(created[0].clientEmail).toBe('jane@bu.edu');
+    expect(created[0].clientInstitution).toBe('Boston University');
+  });
+
+  it('falls back to the username when no display name was captured', async () => {
+    const { service, created } = harness({ job: { _id: 'job1', name: 'Project X', username: 'jrivera', email: 'jane@bu.edu', institute: 'BU' } });
+
+    await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    expect(created[0].clientName).toBe('jrivera');
+  });
+
+  it('does not set a title, so the document keeps one source for the default', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    expect(created[0].sowTitle).toBeUndefined();
+  });
+
+  it('opens the scope with one line per distinct service', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob('job1', [serviceInput({ id: 'a', name: 'PCR' }), serviceInput({ id: 'b', name: 'Gel Electrophoresis' })], 'tech@bu.edu');
+
+    expect(created[0].scopeOfWork).toEqual(['Perform PCR', 'Perform Gel Electrophoresis']);
+  });
+
+  it('counts a service that appears more than once rather than repeating the line', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob('job1', [serviceInput({ id: 'a', name: 'PCR' }), serviceInput({ id: 'a', name: 'PCR' })], 'tech@bu.edu');
+
+    expect(created[0].scopeOfWork).toEqual(['Perform PCR (2 instances)']);
+  });
+
+  it('takes deliverables from the service records, without duplicates', async () => {
+    const { service, created } = harness({ deliverablesById: { a: ['Plasmid DNA', 'Glycerol stocks'], b: ['Plasmid DNA', 'Sequencing report'] } });
+
+    await service.createForJob('job1', [serviceInput({ id: 'a' }), serviceInput({ id: 'b' })], 'tech@bu.edu');
+
+    expect(created[0].deliverables).toEqual(['Plasmid DNA', 'Glycerol stocks', 'Sequencing report']);
+  });
+
+  it('supplies placeholder deliverables when no service defines any', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    // Seeded services usually carry none, and an empty array fails validation —
+    // which would surface to staff as "deliverables cannot be empty".
+    expect(created[0].deliverables.length).toBeGreaterThan(0);
+  });
+
+  it('opens as a draft over a two-week timeline', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    const { startDate, endDate, duration } = created[0].timeline;
+    const days = Math.round((new Date(endDate).getTime() - new Date(startDate).getTime()) / 86400000);
+    expect(days).toBe(14);
+    expect(duration).toBe('14 days');
+    expect(created[0].status).toBe('DRAFT');
+  });
+
+  it('records who generated it', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob('job1', [serviceInput()], 'tech@bu.edu');
+
+    expect(created[0].createdBy).toBe('tech@bu.edu');
+  });
+});

--- a/src/sow/sow-field-calculator.spec.ts
+++ b/src/sow/sow-field-calculator.spec.ts
@@ -95,7 +95,7 @@ describe('period of performance text', () => {
     expect(v).not.toContain('- ');
   });
 
-  it('lists each period and totals the days when there are several', () => {
+  it('lists each period and gives the true period of performance — earliest start to latest end, not summed durations', () => {
     const v = calculateFieldValues(
       inputs({
         periods: [
@@ -108,7 +108,38 @@ describe('period of performance text', () => {
     expect(v).toContain('- Phase 1: 14 days, from March 3, 2026 through March 16, 2026');
     // 7 days from June 1 inclusive ends June 7, matching the 1-day case above.
     expect(v).toContain('- Phase 2: 7 days, from June 1, 2026 through June 7, 2026');
-    expect(v).toContain('21 days');
+    // Summing the two periods' durations would say 21 days; the actual span from
+    // the earliest start (March 3) to the latest end (June 7) is 97 days.
+    expect(v).not.toContain('21 days');
+    expect(v).toContain('The overall period of performance is estimated to be 97 days, from March 3, 2026 through June 7, 2026.');
+  });
+
+  it('takes the span from the earliest start to the latest end even when periods are given out of order', () => {
+    const v = calculateFieldValues(
+      inputs({
+        periods: [
+          { startDate: new Date('2026-06-01T00:00:00Z'), durationDays: 7, label: 'Phase 2' },
+          { startDate: new Date('2026-03-03T00:00:00Z'), durationDays: 14, label: 'Phase 1' }
+        ]
+      }),
+      ctx
+    ).periodOfPerformance;
+    expect(v).toContain('The overall period of performance is estimated to be 97 days, from March 3, 2026 through June 7, 2026.');
+  });
+
+  it('does not overcount overlapping periods as if they were sequential', () => {
+    const v = calculateFieldValues(
+      inputs({
+        periods: [
+          { startDate: new Date('2026-03-03T00:00:00Z'), durationDays: 14, label: 'Phase 1' },
+          { startDate: new Date('2026-03-10T00:00:00Z'), durationDays: 14, label: 'Phase 2' }
+        ]
+      }),
+      ctx
+    ).periodOfPerformance;
+    // Summed durations would claim 28 days; the two overlap, so the true span
+    // (March 3 through March 23) is 21 days.
+    expect(v).toContain('The overall period of performance is estimated to be 21 days, from March 3, 2026 through March 23, 2026.');
   });
 
   it('supports retroactive periods', () => {
@@ -251,5 +282,39 @@ describe('normalizeIncomingFields', () => {
     const out = normalizeIncomingFields([dup, { ...dup, value: 'second' }], inputs(), ctx);
     expect(out.filter((f) => f.key === 'billToAddress')).toHaveLength(1);
     expect(fieldByKey(out, 'billToAddress').value).toBe('first');
+  });
+
+  it('re-enables a required field once it goes from empty to populated', () => {
+    // Version 1 had no PM/Lead: Engagement Resources generated nothing and was
+    // hidden. Staff then pick a PM/Lead — the live preview refreshes the field's
+    // text (as SowEditorModal's runPreview does) but nothing client-side flips
+    // the checkbox, so it still arrives at Save marked hidden.
+    const previousFields = buildCalculatedFields(inputs({ projectManager: '', projectLead: '' }), ctx);
+    expect(fieldByKey(previousFields, 'engagementResources').isEnabled).toBe(false);
+
+    const freshValues = calculateFieldValues(inputs(), ctx);
+    const incoming = previousFields.map(
+      (f) => ({ key: f.key, label: f.label, kind: f.kind, order: f.order, value: freshValues[f.key] ?? f.value, isOverridden: f.isOverridden, isEnabled: false, allowsTextOverride: f.allowsTextOverride } as SowField)
+    );
+
+    const out = normalizeIncomingFields(incoming, inputs(), ctx, previousFields);
+    expect(fieldByKey(out, 'engagementResources').isEnabled).toBe(true);
+    expect(fieldByKey(out, 'engagementResources').value).toContain('Courtney Tretheway');
+  });
+
+  it('does not resurrect a required field the staff deliberately hid after it already had content', () => {
+    const previousFields = buildCalculatedFields(inputs(), ctx); // PM/Lead already set, so it has content
+    expect(fieldByKey(previousFields, 'engagementResources').isEnabled).toBe(true);
+
+    const incoming = previousFields.map((f) => ({ key: f.key, label: f.label, kind: f.kind, order: f.order, value: f.value, isOverridden: f.isOverridden, isEnabled: f.key === 'engagementResources' ? false : f.isEnabled, allowsTextOverride: f.allowsTextOverride } as SowField));
+
+    const out = normalizeIncomingFields(incoming, inputs(), ctx, previousFields);
+    expect(fieldByKey(out, 'engagementResources').isEnabled).toBe(false);
+  });
+
+  it('marks Engagement Resources as required and everything else as allowed to be empty', () => {
+    const out = normalizeIncomingFields([], inputs(), ctx);
+    expect(fieldByKey(out, 'engagementResources').allowsEmpty).toBe(false);
+    expect(fieldByKey(out, 'clientResponsibilities').allowsEmpty).toBe(true);
   });
 });

--- a/src/sow/sow-field-calculator.spec.ts
+++ b/src/sow/sow-field-calculator.spec.ts
@@ -294,7 +294,17 @@ describe('normalizeIncomingFields', () => {
 
     const freshValues = calculateFieldValues(inputs(), ctx);
     const incoming = previousFields.map(
-      (f) => ({ key: f.key, label: f.label, kind: f.kind, order: f.order, value: freshValues[f.key] ?? f.value, isOverridden: f.isOverridden, isEnabled: false, allowsTextOverride: f.allowsTextOverride } as SowField)
+      (f) =>
+        ({
+          key: f.key,
+          label: f.label,
+          kind: f.kind,
+          order: f.order,
+          value: freshValues[f.key] ?? f.value,
+          isOverridden: f.isOverridden,
+          isEnabled: false,
+          allowsTextOverride: f.allowsTextOverride
+        } as SowField)
     );
 
     const out = normalizeIncomingFields(incoming, inputs(), ctx, previousFields);
@@ -306,7 +316,19 @@ describe('normalizeIncomingFields', () => {
     const previousFields = buildCalculatedFields(inputs(), ctx); // PM/Lead already set, so it has content
     expect(fieldByKey(previousFields, 'engagementResources').isEnabled).toBe(true);
 
-    const incoming = previousFields.map((f) => ({ key: f.key, label: f.label, kind: f.kind, order: f.order, value: f.value, isOverridden: f.isOverridden, isEnabled: f.key === 'engagementResources' ? false : f.isEnabled, allowsTextOverride: f.allowsTextOverride } as SowField));
+    const incoming = previousFields.map(
+      (f) =>
+        ({
+          key: f.key,
+          label: f.label,
+          kind: f.kind,
+          order: f.order,
+          value: f.value,
+          isOverridden: f.isOverridden,
+          isEnabled: f.key === 'engagementResources' ? false : f.isEnabled,
+          allowsTextOverride: f.allowsTextOverride
+        } as SowField)
+    );
 
     const out = normalizeIncomingFields(incoming, inputs(), ctx, previousFields);
     expect(fieldByKey(out, 'engagementResources').isEnabled).toBe(false);

--- a/src/sow/sow-field-calculator.spec.ts
+++ b/src/sow/sow-field-calculator.spec.ts
@@ -1,0 +1,255 @@
+import { buildCalculatedFields, calculateFieldValues, mergeCalculatedFields, normalizeIncomingFields, periodEndDate, totalDurationDays, SowDocumentContext } from './sow-field-calculator';
+import { SowField, SowFieldKind, SowVersionInputs } from './sow-version.model';
+import { SOW_FIELD_CATALOG, SOW_PROSE_DEFAULTS } from './sow-field-defaults';
+import { SOWAdjustmentType } from './sow.model';
+
+function inputs(overrides: Partial<SowVersionInputs> = {}): SowVersionInputs {
+  return {
+    projectManager: 'Courtney Tretheway',
+    projectLead: 'Kristen Sheldon',
+    periods: [{ startDate: new Date('2026-03-03T00:00:00Z'), durationDays: 14 }],
+    sowTitle: '',
+    scopeOfWork: ['Run NGS on 70 samples'],
+    deliverables: ['FASTQ files'],
+    services: [{ serviceId: 's1', name: 'Next-gen sequencing', description: '', cost: 350 }],
+    adjustments: [],
+    baseCost: 350,
+    totalCost: 350,
+    customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC',
+    ...overrides
+  } as SowVersionInputs;
+}
+
+const ctx: SowDocumentContext = {
+  sowNumber: 'SOW 001',
+  date: new Date('2026-03-01T00:00:00Z'),
+  jobDisplayId: '1234',
+  jobName: 'Plasmid prep',
+  clientName: 'Jane Rivera',
+  clientEmail: 'jane@lab.org',
+  clientInstitution: 'Example University'
+};
+
+function fieldByKey(fields: SowField[], key: string): SowField {
+  const f = fields.find((x) => x.key === key);
+  if (!f) throw new Error(`no field ${key}`);
+  return f;
+}
+
+describe('period helpers', () => {
+  it('treats a 1-day period as starting and ending the same day', () => {
+    const end = periodEndDate({ startDate: new Date('2026-03-03T00:00:00Z'), durationDays: 1 } as any);
+    expect(end.toISOString().slice(0, 10)).toBe('2026-03-03');
+  });
+
+  it('computes the inclusive end of a multi-day period', () => {
+    const end = periodEndDate({ startDate: new Date('2026-03-03T00:00:00Z'), durationDays: 14 } as any);
+    expect(end.toISOString().slice(0, 10)).toBe('2026-03-16');
+  });
+
+  it('sums durations across periods', () => {
+    expect(totalDurationDays([{ durationDays: 14 } as any, { durationDays: 7 } as any])).toBe(21);
+  });
+});
+
+describe('buildCalculatedFields', () => {
+  it('produces every catalogue field, in order', () => {
+    const fields = buildCalculatedFields(inputs(), ctx);
+    expect(fields).toHaveLength(SOW_FIELD_CATALOG.length);
+    expect(fields.map((f) => f.order)).toEqual([...fields.map((f) => f.order)].sort((a, b) => a - b));
+  });
+
+  it('starts with nothing overridden and value equal to calculatedValue', () => {
+    for (const f of buildCalculatedFields(inputs(), ctx)) {
+      expect(f.isOverridden).toBe(false);
+      expect(f.value).toBe(f.calculatedValue);
+    }
+  });
+
+  it('marks Fee Schedule as not text-overridable, and everything else as overridable', () => {
+    const fields = buildCalculatedFields(inputs(), ctx);
+    expect(fieldByKey(fields, 'feeSchedule').allowsTextOverride).toBe(false);
+    expect(fieldByKey(fields, 'clientResponsibilities').allowsTextOverride).toBe(true);
+  });
+
+  it('disables fields that generate no content rather than emitting a bare heading', () => {
+    const fields = buildCalculatedFields(inputs(), ctx);
+    // additionalInformation defaults to empty
+    expect(fieldByKey(fields, 'additionalInformation').isEnabled).toBe(false);
+    expect(fieldByKey(fields, 'clientResponsibilities').isEnabled).toBe(true);
+  });
+
+  it('carries the standard prose verbatim', () => {
+    const fields = buildCalculatedFields(inputs(), ctx);
+    expect(fieldByKey(fields, 'clientResponsibilities').value).toBe(SOW_PROSE_DEFAULTS.clientResponsibilities);
+    expect(fieldByKey(fields, 'completionCriteria').value).toContain('2-business days');
+  });
+});
+
+describe('period of performance text', () => {
+  it('reads as one stretch for a single period', () => {
+    const v = calculateFieldValues(inputs(), ctx).periodOfPerformance;
+    expect(v).toContain('within 14 days');
+    expect(v).toContain('March 3, 2026');
+    expect(v).toContain('March 16, 2026');
+    expect(v).not.toContain('- ');
+  });
+
+  it('lists each period and totals the days when there are several', () => {
+    const v = calculateFieldValues(
+      inputs({
+        periods: [
+          { startDate: new Date('2026-03-03T00:00:00Z'), durationDays: 14, label: 'Phase 1' },
+          { startDate: new Date('2026-06-01T00:00:00Z'), durationDays: 7, label: 'Phase 2' }
+        ]
+      }),
+      ctx
+    ).periodOfPerformance;
+    expect(v).toContain('- Phase 1: 14 days, from March 3, 2026 through March 16, 2026');
+    // 7 days from June 1 inclusive ends June 7, matching the 1-day case above.
+    expect(v).toContain('- Phase 2: 7 days, from June 1, 2026 through June 7, 2026');
+    expect(v).toContain('21 days');
+  });
+
+  it('supports retroactive periods', () => {
+    const v = calculateFieldValues(inputs({ periods: [{ startDate: new Date('2020-01-06T00:00:00Z'), durationDays: 5 } as any] }), ctx).periodOfPerformance;
+    expect(v).toContain('January 6, 2020');
+  });
+
+  it('is empty when no periods are set, so the section switches off', () => {
+    expect(calculateFieldValues(inputs({ periods: [] }), ctx).periodOfPerformance).toBe('');
+  });
+});
+
+describe('fee schedule text', () => {
+  it('lists services, the pricing category and the total', () => {
+    const v = calculateFieldValues(inputs(), ctx).feeSchedule;
+    expect(v).toContain('Pricing category: External (Academic)');
+    expect(v).toContain('- Next-gen sequencing — $350.00');
+    expect(v).toContain('Total: $350.00');
+  });
+
+  it('shows a discount as negative and an additional cost as positive', () => {
+    const v = calculateFieldValues(
+      inputs({
+        adjustments: [
+          { type: SOWAdjustmentType.DISCOUNT, description: 'Academic discount', amount: 47, reason: 'grant' },
+          { type: SOWAdjustmentType.ADDITIONAL_COST, description: 'Rush handling', amount: 120 }
+        ],
+        totalCost: 423
+      }),
+      ctx
+    ).feeSchedule;
+    expect(v).toContain('- Academic discount — grant: -$47.00');
+    expect(v).toContain('- Rush handling: $120.00');
+    expect(v).toContain('Total: $423.00');
+  });
+});
+
+describe('mergeCalculatedFields', () => {
+  it('refreshes non-overridden text when inputs change', () => {
+    const v1 = buildCalculatedFields(inputs(), ctx);
+    const merged = mergeCalculatedFields(v1, inputs({ projectManager: 'New Manager' }), ctx);
+    expect(fieldByKey(merged, 'engagementResources').value).toContain('New Manager');
+  });
+
+  it('keeps an override but refreshes calculatedValue underneath it', () => {
+    const v1 = buildCalculatedFields(inputs(), ctx);
+    const edited = v1.map((f) => (f.key === 'engagementResources' ? { ...f, value: 'Bespoke wording', isOverridden: true } : f));
+
+    const merged = mergeCalculatedFields(edited, inputs({ projectManager: 'New Manager' }), ctx);
+    const f = fieldByKey(merged, 'engagementResources');
+    expect(f.value).toBe('Bespoke wording');
+    expect(f.isOverridden).toBe(true);
+    // revert must land on today's value, not the one from when the override was made
+    expect(f.calculatedValue).toContain('New Manager');
+  });
+
+  it('preserves a disabled section rather than dropping it', () => {
+    const v1 = buildCalculatedFields(inputs(), ctx);
+    const edited = v1.map((f) => (f.key === 'billToAddress' ? { ...f, isEnabled: false } : f));
+    const merged = mergeCalculatedFields(edited, inputs(), ctx);
+    const f = fieldByKey(merged, 'billToAddress');
+    expect(f.isEnabled).toBe(false);
+    expect(f.value).not.toBe('');
+  });
+
+  it('carries custom fields through untouched and after the catalogue', () => {
+    const v1 = buildCalculatedFields(inputs(), ctx);
+    const withCustom = [
+      ...v1,
+      { key: 'custom-abc', label: 'Shipping', kind: SowFieldKind.CUSTOM, order: 1000, value: 'Dry ice', isOverridden: false, isEnabled: true, allowsTextOverride: true } as SowField
+    ];
+
+    const merged = mergeCalculatedFields(withCustom, inputs(), ctx);
+    const custom = fieldByKey(merged, 'custom-abc');
+    expect(custom.value).toBe('Dry ice');
+    expect(merged[merged.length - 1].key).toBe('custom-abc');
+  });
+
+  it('stops honouring an override on a field that is no longer overridable', () => {
+    // Fee Schedule carries billing figures; a stale override must not win.
+    const v1 = buildCalculatedFields(inputs(), ctx);
+    const tampered = v1.map((f) => (f.key === 'feeSchedule' ? { ...f, value: 'Total: $1.00', isOverridden: true, allowsTextOverride: true } : f));
+
+    const merged = mergeCalculatedFields(tampered, inputs(), ctx);
+    const fee = fieldByKey(merged, 'feeSchedule');
+    expect(fee.isOverridden).toBe(false);
+    expect(fee.value).toContain('Total: $350.00');
+  });
+});
+
+describe('normalizeIncomingFields', () => {
+  it('refuses a client-supplied text override on Fee Schedule', () => {
+    const incoming = [
+      { key: 'feeSchedule', label: 'Fee Schedule', kind: SowFieldKind.CALCULATED, order: 100, value: 'Total: $1.00', isOverridden: true, isEnabled: true, allowsTextOverride: true } as SowField
+    ];
+
+    const fee = fieldByKey(normalizeIncomingFields(incoming, inputs(), ctx), 'feeSchedule');
+    expect(fee.isOverridden).toBe(false);
+    expect(fee.value).toContain('Total: $350.00');
+  });
+
+  it('accepts an override on an ordinary prose field', () => {
+    const incoming = [
+      { key: 'clientResponsibilities', label: 'x', kind: SowFieldKind.PROSE, order: 0, value: 'Client ships on dry ice.', isOverridden: true, isEnabled: true, allowsTextOverride: true } as SowField
+    ];
+
+    const f = fieldByKey(normalizeIncomingFields(incoming, inputs(), ctx), 'clientResponsibilities');
+    expect(f.value).toBe('Client ships on dry ice.');
+    expect(f.isOverridden).toBe(true);
+  });
+
+  it('takes label, kind and order from the catalogue, not the request', () => {
+    const incoming = [{ key: 'billToAddress', label: 'Hacked Heading', kind: SowFieldKind.CUSTOM, order: -5, value: 'x', isOverridden: true, isEnabled: true, allowsTextOverride: true } as SowField];
+
+    const f = fieldByKey(normalizeIncomingFields(incoming, inputs(), ctx), 'billToAddress');
+    expect(f.label).toBe('Bill To Address');
+    expect(f.kind).toBe(SowFieldKind.PROSE);
+    expect(f.order).toBe(110);
+  });
+
+  it('restores omitted catalogue fields as disabled instead of dropping them', () => {
+    const out = normalizeIncomingFields([], inputs(), ctx);
+    expect(out).toHaveLength(SOW_FIELD_CATALOG.length);
+    expect(out.every((f) => !f.isEnabled)).toBe(true);
+  });
+
+  it('keeps custom fields and ignores unknown non-custom keys', () => {
+    const incoming = [
+      { key: 'custom-1', label: 'Shipping', kind: SowFieldKind.CUSTOM, order: 0, value: 'Dry ice', isOverridden: false, isEnabled: true, allowsTextOverride: true },
+      { key: 'notARealField', label: 'x', kind: SowFieldKind.PROSE, order: 0, value: 'x', isOverridden: false, isEnabled: true, allowsTextOverride: true }
+    ] as SowField[];
+
+    const out = normalizeIncomingFields(incoming, inputs(), ctx);
+    expect(out.find((f) => f.key === 'custom-1')?.value).toBe('Dry ice');
+    expect(out.find((f) => f.key === 'notARealField')).toBeUndefined();
+  });
+
+  it('drops duplicate keys rather than emitting the section twice', () => {
+    const dup = { key: 'billToAddress', label: 'x', kind: SowFieldKind.PROSE, order: 0, value: 'first', isOverridden: true, isEnabled: true, allowsTextOverride: true } as SowField;
+    const out = normalizeIncomingFields([dup, { ...dup, value: 'second' }], inputs(), ctx);
+    expect(out.filter((f) => f.key === 'billToAddress')).toHaveLength(1);
+    expect(fieldByKey(out, 'billToAddress').value).toBe('first');
+  });
+});

--- a/src/sow/sow-field-calculator.ts
+++ b/src/sow/sow-field-calculator.ts
@@ -57,6 +57,27 @@ export function totalDurationDays(periods: SowPeriod[]): number {
   return (periods ?? []).reduce((sum, p) => sum + (Number.isFinite(p.durationDays) ? p.durationDays : 0), 0);
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * The true period of performance across possibly-non-consecutive periods: the
+ * span from the earliest start date to the latest end date. Not the same as
+ * summing each period's duration — that overcounts when periods are gapped and
+ * undercounts (relative to the calendar span the prose describes) when they
+ * overlap, and it is the start/end dates that the sentence actually promises.
+ */
+export function periodOfPerformanceSpan(periods: SowPeriod[]): { start: Date; end: Date; days: number } | null {
+  const list = (periods ?? []).filter((p) => p && p.startDate);
+  if (list.length === 0) return null;
+
+  const starts = list.map((p) => (p.startDate instanceof Date ? p.startDate : new Date(p.startDate)));
+  const ends = list.map((p) => periodEndDate(p));
+  const start = new Date(Math.min(...starts.map((d) => d.getTime())));
+  const end = new Date(Math.max(...ends.map((d) => d.getTime())));
+  const days = Math.round((end.getTime() - start.getTime()) / MS_PER_DAY) + 1;
+  return { start, end, days };
+}
+
 function bulletList(lines: string[]): string {
   return lines
     .filter((l) => l && l.trim() !== '')
@@ -103,13 +124,18 @@ function buildPeriodOfPerformance(inputs: SowVersionInputs): string {
     )} and continue until ${formatDate(periodEndDate(p))}.`;
   }
 
-  // Multiple periods may be non-consecutive or retroactive, so state each and
-  // give the total rather than implying one continuous stretch.
+  // Multiple periods may be non-consecutive or retroactive, so state each one,
+  // then give the true period of performance: the span from the earliest start
+  // to the latest end, not the sum of each period's working days.
   const rows = periods.map((p, i) => {
     const label = (p.label || '').trim() || `Period ${i + 1}`;
     return `${label}: ${p.durationDays} days, from ${formatDate(p.startDate)} through ${formatDate(periodEndDate(p))}`;
   });
-  return ['The Operations shall be performed over the following periods:', bulletList(rows), `Total turn-around time is estimated to be ${totalDurationDays(periods)} days.`].join('\n');
+  const span = periodOfPerformanceSpan(periods);
+  const summary = span
+    ? `The overall period of performance is estimated to be ${span.days} days, from ${formatDate(span.start)} through ${formatDate(span.end)}.`
+    : '';
+  return ['The Operations shall be performed over the following periods:', bulletList(rows), summary].join('\n');
 }
 
 function buildEngagementResources(inputs: SowVersionInputs): string {
@@ -207,7 +233,9 @@ export function buildCalculatedFields(inputs: SowVersionInputs, ctx: SowDocument
     isOverridden: false,
     // A section with nothing in it would render as a bare heading.
     isEnabled: def.enabledByDefault && (values[def.key] ?? '').trim() !== '',
-    allowsTextOverride: def.allowsTextOverride
+    allowsTextOverride: def.allowsTextOverride,
+    allowsEmpty: def.allowsEmpty,
+    requiresInitials: false
   }));
 }
 
@@ -239,7 +267,9 @@ export function mergeCalculatedFields(previous: SowField[], inputs: SowVersionIn
         calculatedValue: calculated,
         isOverridden: false,
         isEnabled: def.enabledByDefault && calculated.trim() !== '',
-        allowsTextOverride: def.allowsTextOverride
+        allowsTextOverride: def.allowsTextOverride,
+        allowsEmpty: def.allowsEmpty,
+        requiresInitials: false
       });
       continue;
     }
@@ -249,14 +279,23 @@ export function mergeCalculatedFields(previous: SowField[], inputs: SowVersionIn
     const canOverride = def.allowsTextOverride;
     const isOverridden = canOverride && prev.isOverridden;
 
+    // A required field that was hidden only because it had nothing to say gets a
+    // second chance to show itself once content arrives — otherwise it stays
+    // hidden forever after the first empty save, with no visible way to notice.
+    // A field the staff hid while it already had content is left alone.
+    const wasEmptyAndRequired = def.allowsEmpty === false && (prev.calculatedValue ?? '').trim() === '';
+    const justPopulated = wasEmptyAndRequired && calculated.trim() !== '';
+
     merged.push({
       ...prev,
       label: def.label,
       kind: def.kind,
       order: def.order,
       allowsTextOverride: canOverride,
+      allowsEmpty: def.allowsEmpty,
       calculatedValue: calculated,
       isOverridden,
+      isEnabled: prev.isEnabled || justPopulated,
       value: isOverridden ? prev.value : calculated
     });
   }
@@ -273,8 +312,9 @@ export function mergeCalculatedFields(previous: SowField[], inputs: SowVersionIn
  * than the request, so a caller cannot relabel a section, reorder the document,
  * or grant itself a text override on Fee Schedule.
  */
-export function normalizeIncomingFields(incoming: SowField[], inputs: SowVersionInputs, ctx: SowDocumentContext): SowField[] {
+export function normalizeIncomingFields(incoming: SowField[], inputs: SowVersionInputs, ctx: SowDocumentContext, previousFields: SowField[] = []): SowField[] {
   const values = calculateFieldValues(inputs, ctx);
+  const prevByKey = new Map(previousFields.map((f) => [f.key, f]));
   const seen = new Set<string>();
   const out: SowField[] = [];
 
@@ -292,7 +332,9 @@ export function normalizeIncomingFields(incoming: SowField[], inputs: SowVersion
         calculatedValue: undefined,
         isOverridden: false,
         isEnabled: field.isEnabled !== false,
-        allowsTextOverride: true
+        allowsTextOverride: true,
+        allowsEmpty: true,
+        requiresInitials: field.requiresInitials === true
       });
       continue;
     }
@@ -303,6 +345,13 @@ export function normalizeIncomingFields(incoming: SowField[], inputs: SowVersion
     const calculated = values[def.key] ?? '';
     const isOverridden = def.allowsTextOverride && (field.value ?? '') !== calculated;
 
+    // A required field the client sent as hidden gets shown again if it was
+    // hidden only for lack of content and now has some — see mergeCalculatedFields
+    // for why this doesn't resurrect a field staff hid deliberately.
+    const prev = prevByKey.get(def.key);
+    const wasEmptyAndRequired = def.allowsEmpty === false && (prev?.calculatedValue ?? '').trim() === '';
+    const justPopulated = wasEmptyAndRequired && calculated.trim() !== '';
+
     out.push({
       key: def.key,
       label: def.label,
@@ -311,8 +360,10 @@ export function normalizeIncomingFields(incoming: SowField[], inputs: SowVersion
       value: isOverridden ? field.value : calculated,
       calculatedValue: calculated,
       isOverridden,
-      isEnabled: field.isEnabled !== false,
-      allowsTextOverride: def.allowsTextOverride
+      isEnabled: field.isEnabled !== false || justPopulated,
+      allowsTextOverride: def.allowsTextOverride,
+      allowsEmpty: def.allowsEmpty,
+      requiresInitials: field.requiresInitials === true
     });
   }
 
@@ -330,7 +381,9 @@ export function normalizeIncomingFields(incoming: SowField[], inputs: SowVersion
       calculatedValue: calculated,
       isOverridden: false,
       isEnabled: false,
-      allowsTextOverride: def.allowsTextOverride
+      allowsTextOverride: def.allowsTextOverride,
+      allowsEmpty: def.allowsEmpty,
+      requiresInitials: false
     });
   }
 

--- a/src/sow/sow-field-calculator.ts
+++ b/src/sow/sow-field-calculator.ts
@@ -1,0 +1,338 @@
+import { SowField, SowFieldKind, SowVersionInputs, SowPeriod } from './sow-version.model';
+import { SOWAdjustmentType } from './sow.model';
+import { CUSTOM_FIELD_ORDER_BASE, SOW_FIELD_CATALOG, SOW_PROSE_DEFAULTS, customerCategoryLabel, findFieldDefinition, isCustomFieldKey } from './sow-field-defaults';
+
+/**
+ * Generates the SOW document text from structured inputs.
+ *
+ * This runs server-side only. The frontend never composes document prose or
+ * totals — it renders what this produces. Keeping one implementation is
+ * deliberate: the pricing logic already exists twice (damplab-ui/src/utils/
+ * servicePricing.ts and src/pricing/service-pricing.util.ts) and the copies
+ * drifted far enough to break SOW saves outright, which is a mistake worth not
+ * repeating for the document itself.
+ *
+ * Output is plain text. A line beginning "- " is a bullet; renderers (web and
+ * PDF) agree on that and nothing else.
+ */
+
+export interface SowDocumentContext {
+  sowNumber?: string;
+  date?: Date;
+  jobDisplayId?: string;
+  jobName?: string;
+  clientName?: string;
+  clientEmail?: string;
+  clientInstitution?: string;
+  clientAddress?: string;
+}
+
+const DEFAULT_SOW_TITLE = 'Agreement to Perform Research Operations';
+
+function formatDate(value: Date | string | undefined): string {
+  if (!value) return '';
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  // Matches formatSOWDate in damplab-ui: month name, day, full year, in UTC so a
+  // date-only value does not slip a day for readers west of Greenwich.
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+}
+
+function formatCurrency(amount: number): string {
+  const n = Number.isFinite(amount) ? amount : 0;
+  // Sign goes outside the symbol: "-$47.00", not "$-47.00".
+  const magnitude = Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return `${n < 0 ? '-' : ''}$${magnitude}`;
+}
+
+export function periodEndDate(period: SowPeriod): Date {
+  const start = period.startDate instanceof Date ? period.startDate : new Date(period.startDate);
+  const end = new Date(start.getTime());
+  // A 1-day period starts and ends the same day, so advance by duration - 1.
+  end.setUTCDate(end.getUTCDate() + Math.max(0, (period.durationDays ?? 0) - 1));
+  return end;
+}
+
+export function totalDurationDays(periods: SowPeriod[]): number {
+  return (periods ?? []).reduce((sum, p) => sum + (Number.isFinite(p.durationDays) ? p.durationDays : 0), 0);
+}
+
+function bulletList(lines: string[]): string {
+  return lines
+    .filter((l) => l && l.trim() !== '')
+    .map((l) => `- ${l.trim()}`)
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Per-field generators
+// ---------------------------------------------------------------------------
+
+function buildTitle(inputs: SowVersionInputs, ctx: SowDocumentContext): string {
+  const title = (inputs.sowTitle || '').trim() || DEFAULT_SOW_TITLE;
+  const job = ctx.jobDisplayId ? `Job #${ctx.jobDisplayId} for ` : '';
+  const client = ctx.clientName ? ` for ${ctx.clientName}` : '';
+  return `${job}${title}${client}`;
+}
+
+function buildParties(ctx: SowDocumentContext): string {
+  const lines = [
+    `Date of Agreement: ${formatDate(ctx.date)}`,
+    '',
+    'Operations Performed By:',
+    'Trustees of Boston University',
+    'DAMP Lab of Boston University',
+    '610 Commonwealth Avenue',
+    'Boston, MA 02215',
+    '',
+    `Operations Performed For: ${ctx.clientName ?? ''}`
+  ];
+  if (ctx.clientInstitution) lines.push(ctx.clientInstitution);
+  if (ctx.clientAddress) lines.push(ctx.clientAddress);
+  return lines.join('\n');
+}
+
+function buildPeriodOfPerformance(inputs: SowVersionInputs): string {
+  const periods = (inputs.periods ?? []).filter((p) => p && p.startDate);
+  if (periods.length === 0) return '';
+
+  if (periods.length === 1) {
+    const p = periods[0];
+    return `The total turn-around time is estimated to be within ${p.durationDays} days from the start date. Therefore, the services herewith mentioned shall commence on ${formatDate(
+      p.startDate
+    )} and continue until ${formatDate(periodEndDate(p))}.`;
+  }
+
+  // Multiple periods may be non-consecutive or retroactive, so state each and
+  // give the total rather than implying one continuous stretch.
+  const rows = periods.map((p, i) => {
+    const label = (p.label || '').trim() || `Period ${i + 1}`;
+    return `${label}: ${p.durationDays} days, from ${formatDate(p.startDate)} through ${formatDate(periodEndDate(p))}`;
+  });
+  return ['The Operations shall be performed over the following periods:', bulletList(rows), `Total turn-around time is estimated to be ${totalDurationDays(periods)} days.`].join('\n');
+}
+
+function buildEngagementResources(inputs: SowVersionInputs): string {
+  const people: string[] = [];
+  if ((inputs.projectManager || '').trim()) people.push(`${inputs.projectManager.trim()} – Project Manager`);
+  if ((inputs.projectLead || '').trim()) people.push(`${inputs.projectLead.trim()} – Project Lead`);
+  if (people.length === 0) return '';
+  return ['The Operations contemplated by this SOW shall be performed by the DAMP team, which shall include the following individuals:', bulletList(people)].join('\n');
+}
+
+function buildFeeSchedule(inputs: SowVersionInputs): string {
+  const lines: string[] = [
+    'This engagement will be conducted on a Project basis. The total value for the Operations pursuant to this SOW is presented below.',
+    '',
+    `Pricing category: ${customerCategoryLabel(inputs.customerCategory)}`,
+    ''
+  ];
+
+  const serviceRows = (inputs.services ?? []).map((s) => `${s.name} — ${formatCurrency(s.cost)}`);
+  lines.push(...(serviceRows.length ? [bulletList(serviceRows)] : ['- No services listed']));
+
+  const adjustments = inputs.adjustments ?? [];
+  if (adjustments.length > 0) {
+    const adjRows = adjustments.map((a) => {
+      const desc = (a.description || '').trim() || (a.type === SOWAdjustmentType.DISCOUNT ? 'Discount' : 'Additional cost');
+      const reason = (a.reason || '').trim();
+      const label = reason ? `${desc} — ${reason}` : desc;
+      const signed = a.type === SOWAdjustmentType.DISCOUNT ? -Math.abs(a.amount) : Math.abs(a.amount);
+      return `${label}: ${formatCurrency(signed)}`;
+    });
+    lines.push(bulletList(adjRows));
+  }
+
+  lines.push(
+    '',
+    `Total: ${formatCurrency(inputs.totalCost)}`,
+    '',
+    'Upon completion of the initial performance period, University and the Client will have the option to renew this SOW for an additional then-stated project for those resources identified.'
+  );
+  return lines.join('\n');
+}
+
+function calculatedValueFor(key: string, inputs: SowVersionInputs, ctx: SowDocumentContext): string {
+  switch (key) {
+    case 'sowTitle':
+      return buildTitle(inputs, ctx);
+    case 'parties':
+      return buildParties(ctx);
+    case 'periodOfPerformance':
+      return buildPeriodOfPerformance(inputs);
+    case 'engagementResources':
+      return buildEngagementResources(inputs);
+    case 'scopeOfWork':
+      return bulletList(inputs.scopeOfWork ?? []);
+    case 'deliverables':
+      return bulletList(inputs.deliverables ?? []);
+    case 'feeSchedule':
+      return buildFeeSchedule(inputs);
+    default:
+      return SOW_PROSE_DEFAULTS[key] ?? '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * The generated value of every catalogue field, keyed by field key. This is what
+ * the preview query returns: only what the server owns. The client keeps its own
+ * `value` / `isOverridden` / `isEnabled`, which may include unsaved edits the
+ * server has never seen, so returning whole rows here would clobber them.
+ */
+export function calculateFieldValues(inputs: SowVersionInputs, ctx: SowDocumentContext): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const def of SOW_FIELD_CATALOG) {
+    out[def.key] = calculatedValueFor(def.key, inputs, ctx);
+  }
+  return out;
+}
+
+/**
+ * A fresh document: every catalogue field at its generated value, nothing
+ * overridden. Used when a SOW gets its first version.
+ */
+export function buildCalculatedFields(inputs: SowVersionInputs, ctx: SowDocumentContext): SowField[] {
+  const values = calculateFieldValues(inputs, ctx);
+  return SOW_FIELD_CATALOG.map((def) => ({
+    key: def.key,
+    label: def.label,
+    kind: def.kind,
+    order: def.order,
+    value: values[def.key] ?? '',
+    calculatedValue: values[def.key] ?? '',
+    isOverridden: false,
+    // A section with nothing in it would render as a bare heading.
+    isEnabled: def.enabledByDefault && (values[def.key] ?? '').trim() !== '',
+    allowsTextOverride: def.allowsTextOverride
+  }));
+}
+
+/**
+ * Refreshes generated text over an existing document, preserving staff intent.
+ *
+ * Overridden fields keep their text but get a current `calculatedValue`, so
+ * "revert to calculated" lands on today's value rather than the one from
+ * whenever the override was made. Fields the staff disabled stay disabled.
+ * Custom fields pass through untouched — nothing generates them.
+ */
+export function mergeCalculatedFields(previous: SowField[], inputs: SowVersionInputs, ctx: SowDocumentContext): SowField[] {
+  const values = calculateFieldValues(inputs, ctx);
+  const byKey = new Map(previous.map((f) => [f.key, f]));
+  const merged: SowField[] = [];
+
+  for (const def of SOW_FIELD_CATALOG) {
+    const prev = byKey.get(def.key);
+    const calculated = values[def.key] ?? '';
+
+    if (!prev) {
+      // A section added to the catalogue after this version was written.
+      merged.push({
+        key: def.key,
+        label: def.label,
+        kind: def.kind,
+        order: def.order,
+        value: calculated,
+        calculatedValue: calculated,
+        isOverridden: false,
+        isEnabled: def.enabledByDefault && calculated.trim() !== '',
+        allowsTextOverride: def.allowsTextOverride
+      });
+      continue;
+    }
+
+    // allowsTextOverride is a property of the catalogue, not of stored data: if a
+    // field becomes billing-backed later, any stale override must stop winning.
+    const canOverride = def.allowsTextOverride;
+    const isOverridden = canOverride && prev.isOverridden;
+
+    merged.push({
+      ...prev,
+      label: def.label,
+      kind: def.kind,
+      order: def.order,
+      allowsTextOverride: canOverride,
+      calculatedValue: calculated,
+      isOverridden,
+      value: isOverridden ? prev.value : calculated
+    });
+  }
+
+  // Custom fields keep their relative order after the catalogue.
+  const customs = previous.filter((f) => isCustomFieldKey(f.key)).map((f, i) => ({ ...f, kind: SowFieldKind.CUSTOM, order: CUSTOM_FIELD_ORDER_BASE + i, allowsTextOverride: true }));
+
+  return [...merged, ...customs].sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Normalizes fields arriving from a client before they are frozen into a version.
+ * Labels, kinds, order and override permission come from the catalogue rather
+ * than the request, so a caller cannot relabel a section, reorder the document,
+ * or grant itself a text override on Fee Schedule.
+ */
+export function normalizeIncomingFields(incoming: SowField[], inputs: SowVersionInputs, ctx: SowDocumentContext): SowField[] {
+  const values = calculateFieldValues(inputs, ctx);
+  const seen = new Set<string>();
+  const out: SowField[] = [];
+
+  for (const field of incoming ?? []) {
+    if (!field?.key || seen.has(field.key)) continue;
+    seen.add(field.key);
+
+    if (isCustomFieldKey(field.key)) {
+      out.push({
+        key: field.key,
+        label: (field.label || '').trim() || 'Untitled section',
+        kind: SowFieldKind.CUSTOM,
+        order: CUSTOM_FIELD_ORDER_BASE + out.filter((f) => isCustomFieldKey(f.key)).length,
+        value: field.value ?? '',
+        calculatedValue: undefined,
+        isOverridden: false,
+        isEnabled: field.isEnabled !== false,
+        allowsTextOverride: true
+      });
+      continue;
+    }
+
+    const def = findFieldDefinition(field.key);
+    if (!def) continue; // unknown key: not in the catalogue and not custom
+
+    const calculated = values[def.key] ?? '';
+    const isOverridden = def.allowsTextOverride && (field.value ?? '') !== calculated;
+
+    out.push({
+      key: def.key,
+      label: def.label,
+      kind: def.kind,
+      order: def.order,
+      value: isOverridden ? field.value : calculated,
+      calculatedValue: calculated,
+      isOverridden,
+      isEnabled: field.isEnabled !== false,
+      allowsTextOverride: def.allowsTextOverride
+    });
+  }
+
+  // Any catalogue field the client omitted is restored at its generated value and
+  // disabled, so a partial request cannot silently drop a section of the contract.
+  for (const def of SOW_FIELD_CATALOG) {
+    if (seen.has(def.key)) continue;
+    const calculated = values[def.key] ?? '';
+    out.push({
+      key: def.key,
+      label: def.label,
+      kind: def.kind,
+      order: def.order,
+      value: calculated,
+      calculatedValue: calculated,
+      isOverridden: false,
+      isEnabled: false,
+      allowsTextOverride: def.allowsTextOverride
+    });
+  }
+
+  return out.sort((a, b) => a.order - b.order);
+}

--- a/src/sow/sow-field-calculator.ts
+++ b/src/sow/sow-field-calculator.ts
@@ -132,9 +132,7 @@ function buildPeriodOfPerformance(inputs: SowVersionInputs): string {
     return `${label}: ${p.durationDays} days, from ${formatDate(p.startDate)} through ${formatDate(periodEndDate(p))}`;
   });
   const span = periodOfPerformanceSpan(periods);
-  const summary = span
-    ? `The overall period of performance is estimated to be ${span.days} days, from ${formatDate(span.start)} through ${formatDate(span.end)}.`
-    : '';
+  const summary = span ? `The overall period of performance is estimated to be ${span.days} days, from ${formatDate(span.start)} through ${formatDate(span.end)}.` : '';
   return ['The Operations shall be performed over the following periods:', bulletList(rows), summary].join('\n');
 }
 

--- a/src/sow/sow-field-defaults.ts
+++ b/src/sow/sow-field-defaults.ts
@@ -25,6 +25,15 @@ export interface SowFieldDefinition {
    */
   allowsTextOverride: boolean;
   enabledByDefault: boolean;
+  /**
+   * False on fields the document cannot be sent without. Blocks "Send to
+   * customer" while the generated text is empty, and — since an empty required
+   * field would otherwise sit hidden with no way for staff to notice it needs
+   * attention — lets the field re-enable itself once its content arrives (see
+   * normalizeIncomingFields / mergeCalculatedFields), rather than staying hidden
+   * forever after the first empty save.
+   */
+  allowsEmpty: boolean;
 }
 
 export const SOW_PROSE_DEFAULTS: Record<string, string> = {
@@ -70,27 +79,29 @@ export const SOW_PROSE_DEFAULTS: Record<string, string> = {
 const { CALCULATED, PROSE } = SowFieldKind;
 
 export const SOW_FIELD_CATALOG: SowFieldDefinition[] = [
-  { key: 'sowTitle', label: 'Title', kind: CALCULATED, order: 10, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'parties', label: 'Parties', kind: CALCULATED, order: 20, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'statementOfWork', label: 'Statement of Work', kind: PROSE, order: 30, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'periodOfPerformance', label: 'Period of Performance', kind: CALCULATED, order: 40, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'engagementResources', label: 'Engagement Resources', kind: CALCULATED, order: 50, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'scopeOfWork', label: 'Scope of Work', kind: CALCULATED, order: 60, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'deliverables', label: 'Deliverables', kind: CALCULATED, order: 70, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'universityResponsibilities', label: 'University Responsibilities', kind: PROSE, order: 80, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'clientResponsibilities', label: 'Client Responsibilities', kind: PROSE, order: 90, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'sowTitle', label: 'Title', kind: CALCULATED, order: 10, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'parties', label: 'Parties', kind: CALCULATED, order: 20, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'statementOfWork', label: 'Statement of Work', kind: PROSE, order: 30, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'periodOfPerformance', label: 'Period of Performance', kind: CALCULATED, order: 40, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  // Requires a Project Manager and Project Lead to say anything; staff must set
+  // both before the document can be sent (see sendToCustomer's validation).
+  { key: 'engagementResources', label: 'Engagement Resources', kind: CALCULATED, order: 50, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: false },
+  { key: 'scopeOfWork', label: 'Scope of Work', kind: CALCULATED, order: 60, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'deliverables', label: 'Deliverables', kind: CALCULATED, order: 70, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'universityResponsibilities', label: 'University Responsibilities', kind: PROSE, order: 80, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'clientResponsibilities', label: 'Client Responsibilities', kind: PROSE, order: 90, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
   // The only field with no pencil: its figures are what invoices bill from.
-  { key: 'feeSchedule', label: 'Fee Schedule', kind: CALCULATED, order: 100, allowsTextOverride: false, enabledByDefault: true },
-  { key: 'billToAddress', label: 'Bill To Address', kind: PROSE, order: 110, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'invoiceProcedures', label: 'Invoice Procedures', kind: PROSE, order: 120, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'completionCriteria', label: 'Completion Criteria', kind: PROSE, order: 130, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'projectChangeControl', label: 'Project Change Control Procedure', kind: PROSE, order: 140, allowsTextOverride: true, enabledByDefault: true },
-  { key: 'additionalInformation', label: 'Additional Information', kind: PROSE, order: 150, allowsTextOverride: true, enabledByDefault: false },
+  { key: 'feeSchedule', label: 'Fee Schedule', kind: CALCULATED, order: 100, allowsTextOverride: false, enabledByDefault: true, allowsEmpty: true },
+  { key: 'billToAddress', label: 'Bill To Address', kind: PROSE, order: 110, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'invoiceProcedures', label: 'Invoice Procedures', kind: PROSE, order: 120, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'completionCriteria', label: 'Completion Criteria', kind: PROSE, order: 130, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'projectChangeControl', label: 'Project Change Control Procedure', kind: PROSE, order: 140, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true },
+  { key: 'additionalInformation', label: 'Additional Information', kind: PROSE, order: 150, allowsTextOverride: true, enabledByDefault: false, allowsEmpty: true },
   // Previously an overload in sowGenerator.ts that silently rewrote clientName /
   // clientInstitution. Now ordinary sections, off unless staff fill them in.
-  { key: 'clientProjectManager', label: 'Client Project Manager', kind: PROSE, order: 160, allowsTextOverride: true, enabledByDefault: false },
-  { key: 'clientCostCenter', label: 'Client Cost Center', kind: PROSE, order: 170, allowsTextOverride: true, enabledByDefault: false },
-  { key: 'signatures', label: 'Signatures', kind: PROSE, order: 180, allowsTextOverride: true, enabledByDefault: true }
+  { key: 'clientProjectManager', label: 'Client Project Manager', kind: PROSE, order: 160, allowsTextOverride: true, enabledByDefault: false, allowsEmpty: true },
+  { key: 'clientCostCenter', label: 'Client Cost Center', kind: PROSE, order: 170, allowsTextOverride: true, enabledByDefault: false, allowsEmpty: true },
+  { key: 'signatures', label: 'Signatures', kind: PROSE, order: 180, allowsTextOverride: true, enabledByDefault: true, allowsEmpty: true }
 ];
 
 /** Custom fields sort after everything in the catalog. */

--- a/src/sow/sow-field-defaults.ts
+++ b/src/sow/sow-field-defaults.ts
@@ -1,0 +1,118 @@
+import { SowFieldKind } from './sow-version.model';
+
+/**
+ * The SOW document catalogue: one entry per section, in document order.
+ *
+ * This is the single source of truth for the SOW's language. It replaces two
+ * copies that had already drifted apart — the prose hardcoded in
+ * damplab-ui/src/components/SOWDocument.tsx (which the PDF rendered) and the
+ * near-duplicate built by sowGenerator.ts::getStandardTerms() into sow.terms
+ * (which nothing rendered). The text below is taken verbatim from the PDF, the
+ * copy customers have actually been signing.
+ */
+
+export interface SowFieldDefinition {
+  key: string;
+  label: string;
+  kind: SowFieldKind;
+  /** Ascending; spaced by 10 so sections can be inserted without renumbering. */
+  order: number;
+  /**
+   * False where the text carries figures another system bills from. Fee Schedule
+   * is generated from the billing core that invoices read, so free-text editing
+   * there would let the document quietly disagree with the invoice. Staff change
+   * those numbers through the adjustments and per-service cost controls instead.
+   */
+  allowsTextOverride: boolean;
+  enabledByDefault: boolean;
+}
+
+export const SOW_PROSE_DEFAULTS: Record<string, string> = {
+  statementOfWork: [
+    'This Statement of Work (SOW) contains price and time information as per the discussions between the Trustees of Boston University on behalf of the DAMP Lab at Boston University (hereinafter, "DAMP") and the potential client, to be officially reviewed and assigned by both parties. It contains the description of the services to be performed by DAMP, with relevant costs and terms, including scope of work, deliverables, and responsibilities of DAMP.',
+    '',
+    'This SOW is entered into by and between DAMP and the Client and is subject to the terms and conditions specified below. The Exhibit(s) to this SOW, if any, shall be deemed to be a part hereof. In the event of any inconsistency between the terms of the body of this SOW and the terms of the Exhibit(s) hereto, the terms of the body of this SOW shall prevail.'
+  ].join('\n'),
+
+  universityResponsibilities:
+    'It is the responsibility of the University to provide regular and detailed updates about the Project and Project development, and to ensure that services are delivered on time with high-quality results and that the agreed number of service hours dedicated by the DAMP Lab team for the Project are rendered.',
+
+  clientResponsibilities: 'The client is responsible for delivering all necessary materials and samples to the DAMP Lab for processing as well as all data analysis unless otherwise specified.',
+
+  billToAddress: '610 Commonwealth Avenue, 4th Floor, Room 421, Boston – MA – 02215.',
+
+  invoiceProcedures: [
+    'Client will be invoiced for the Operations. It is agreed by the parties that standard invoicing is acceptable. Payments are due upon receipt of such invoices.',
+    '',
+    'Invoices shall be submitted in arrears, referencing this SOW Number to the address indicated above. Terms of payment for the invoice are due upon receipt by Client of a proper invoice. DAMP Lab shall provide Client with sufficient details to support its invoices, including list of services performed and justifications for authorized expenses, unless otherwise agreed to by the parties.'
+  ].join('\n'),
+
+  completionCriteria: [
+    'DAMP Lab shall have fulfilled its obligations when any one of the following first occurs:',
+    '- DAMP Lab completes the Operations described within this SOW, and Client accepts such Operations without unreasonable objections. No response from Client within 2-business days of deliverables being delivered by DAMP Lab is deemed acceptance.',
+    '- DAMP Lab and/or Client has the right to cancel the Operations not yet provided with 20 business days advance written notice to the other party.'
+  ].join('\n'),
+
+  projectChangeControl: [
+    'The following process will be followed if a change to this SOW is required:',
+    '- A Project Change Request (PCR) will be the vehicle for communicating change. The PCR must describe the change, the rationale for the change, and the effect the change will have on the Project.',
+    '- The designated Project Manager of the requesting party (University or Client) will review the proposed change and determine whether to submit a request to the other party.',
+    '- Both Project Managers will review the proposed change and approve it for further consideration or reject it. The parties shall determine the effect that the implementation of the PCR will have on SOW price, schedule and other terms and conditions of the Agreement.'
+  ].join('\n'),
+
+  signatures: 'IN WITNESS WHEREOF, the parties hereto have caused this SOW to be effective as of the day, month and year first written above.',
+
+  additionalInformation: '',
+  clientProjectManager: '',
+  clientCostCenter: ''
+};
+
+const { CALCULATED, PROSE } = SowFieldKind;
+
+export const SOW_FIELD_CATALOG: SowFieldDefinition[] = [
+  { key: 'sowTitle', label: 'Title', kind: CALCULATED, order: 10, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'parties', label: 'Parties', kind: CALCULATED, order: 20, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'statementOfWork', label: 'Statement of Work', kind: PROSE, order: 30, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'periodOfPerformance', label: 'Period of Performance', kind: CALCULATED, order: 40, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'engagementResources', label: 'Engagement Resources', kind: CALCULATED, order: 50, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'scopeOfWork', label: 'Scope of Work', kind: CALCULATED, order: 60, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'deliverables', label: 'Deliverables', kind: CALCULATED, order: 70, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'universityResponsibilities', label: 'University Responsibilities', kind: PROSE, order: 80, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'clientResponsibilities', label: 'Client Responsibilities', kind: PROSE, order: 90, allowsTextOverride: true, enabledByDefault: true },
+  // The only field with no pencil: its figures are what invoices bill from.
+  { key: 'feeSchedule', label: 'Fee Schedule', kind: CALCULATED, order: 100, allowsTextOverride: false, enabledByDefault: true },
+  { key: 'billToAddress', label: 'Bill To Address', kind: PROSE, order: 110, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'invoiceProcedures', label: 'Invoice Procedures', kind: PROSE, order: 120, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'completionCriteria', label: 'Completion Criteria', kind: PROSE, order: 130, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'projectChangeControl', label: 'Project Change Control Procedure', kind: PROSE, order: 140, allowsTextOverride: true, enabledByDefault: true },
+  { key: 'additionalInformation', label: 'Additional Information', kind: PROSE, order: 150, allowsTextOverride: true, enabledByDefault: false },
+  // Previously an overload in sowGenerator.ts that silently rewrote clientName /
+  // clientInstitution. Now ordinary sections, off unless staff fill them in.
+  { key: 'clientProjectManager', label: 'Client Project Manager', kind: PROSE, order: 160, allowsTextOverride: true, enabledByDefault: false },
+  { key: 'clientCostCenter', label: 'Client Cost Center', kind: PROSE, order: 170, allowsTextOverride: true, enabledByDefault: false },
+  { key: 'signatures', label: 'Signatures', kind: PROSE, order: 180, allowsTextOverride: true, enabledByDefault: true }
+];
+
+/** Custom fields sort after everything in the catalog. */
+export const CUSTOM_FIELD_ORDER_BASE = 1000;
+
+export const CUSTOM_FIELD_KEY_PREFIX = 'custom-';
+
+export function isCustomFieldKey(key: string): boolean {
+  return key.startsWith(CUSTOM_FIELD_KEY_PREFIX);
+}
+
+export function findFieldDefinition(key: string): SowFieldDefinition | undefined {
+  return SOW_FIELD_CATALOG.find((d) => d.key === key);
+}
+
+export const CUSTOMER_CATEGORY_LABELS: Record<string, string> = {
+  INTERNAL_CUSTOMERS: 'Internal customers',
+  EXTERNAL_CUSTOMER_ACADEMIC: 'External (Academic)',
+  EXTERNAL_CUSTOMER_MARKET: 'External (Market)',
+  EXTERNAL_CUSTOMER_NO_SALARY: 'External (No salary)'
+};
+
+export function customerCategoryLabel(category?: string | null): string {
+  return (category && CUSTOMER_CATEGORY_LABELS[category]) || 'Customer category';
+}

--- a/src/sow/sow-number.spec.ts
+++ b/src/sow/sow-number.spec.ts
@@ -1,0 +1,58 @@
+import { SOWService } from './sow.service';
+
+/**
+ * SOW numbering. The failure this guards against is a duplicate: sorting numbers
+ * as strings can rank a smaller one highest, so the "next" number is one that
+ * already exists and the unique index rejects the insert.
+ */
+
+function serviceWith(sowNumbers: string[]): SOWService {
+  const model: any = {
+    find: () => ({ lean: () => ({ exec: async () => sowNumbers.map((sowNumber) => ({ sowNumber })) }) })
+  };
+  return new SOWService(model, {} as any, {} as any, {} as any);
+}
+
+describe('parseSowNumber', () => {
+  it('reads the numeric part regardless of padding', () => {
+    expect(SOWService.parseSowNumber('SOW 001')).toBe(1);
+    expect(SOWService.parseSowNumber('SOW 00012')).toBe(12);
+    expect(SOWService.parseSowNumber('sow 42')).toBe(42);
+  });
+
+  it('returns null for anything it cannot read', () => {
+    expect(SOWService.parseSowNumber('draft')).toBeNull();
+    expect(SOWService.parseSowNumber(undefined)).toBeNull();
+    expect(SOWService.parseSowNumber(null)).toBeNull();
+  });
+});
+
+describe('generateSOWNumber', () => {
+  it('starts at 1 when there are no SOWs', async () => {
+    await expect(serviceWith([]).generateSOWNumber()).resolves.toBe('SOW 00001');
+  });
+
+  it('continues from the highest number', async () => {
+    await expect(serviceWith(['SOW 00004', 'SOW 00012']).generateSOWNumber()).resolves.toBe('SOW 00013');
+  });
+
+  it('compares numerically, not as strings', async () => {
+    // A string sort ranks "SOW 013" above "SOW 00099"; taking that as the maximum
+    // would return "SOW 00014", a number below one already in use.
+    await expect(serviceWith(['SOW 013', 'SOW 00099']).generateSOWNumber()).resolves.toBe('SOW 00100');
+  });
+
+  it('emits one consistent width, whatever the existing rows look like', async () => {
+    await expect(serviceWith(['SOW 001']).generateSOWNumber()).resolves.toBe('SOW 00002');
+  });
+
+  it('steps past a number that is taken but unparseable in the maximum', async () => {
+    // "SOW 00003" is present, so 3 must not be handed out again even though the
+    // highest parseable value is 2.
+    await expect(serviceWith(['SOW 00002', 'SOW 00003']).generateSOWNumber()).resolves.toBe('SOW 00004');
+  });
+
+  it('ignores rows whose number cannot be parsed', async () => {
+    await expect(serviceWith(['pending', 'SOW 00007']).generateSOWNumber()).resolves.toBe('SOW 00008');
+  });
+});

--- a/src/sow/sow-version-fields.resolver.ts
+++ b/src/sow/sow-version-fields.resolver.ts
@@ -1,0 +1,15 @@
+import { Resolver, ResolveField, Parent } from '@nestjs/graphql';
+import { SowVersion } from './sow-version.model';
+import { SowVersionService } from './sow-version.service';
+
+/**
+ * Fields derived purely from a SowVersion's own data, needing no database
+ * access. Kept separate from SOWResolver, which resolves fields of SOW itself.
+ */
+@Resolver(() => SowVersion)
+export class SowVersionFieldsResolver {
+  @ResolveField(() => String, { description: 'Human-facing label "<sent-count>.<sub-revision>", e.g. "1.2" — decoded from versionNumber.' })
+  displayVersion(@Parent() version: SowVersion): string {
+    return SowVersionService.displayVersionLabel(version.versionNumber);
+  }
+}

--- a/src/sow/sow-version.model.ts
+++ b/src/sow/sow-version.model.ts
@@ -68,6 +68,14 @@ export class SowField {
     description: 'False on fields whose text carries figures another system bills from (Fee Schedule), where free-text editing would let the document disagree with the invoice'
   })
   allowsTextOverride: boolean;
+
+  @Prop({ required: true, default: true })
+  @Field({ description: 'False on fields the document cannot be sent to the customer without (e.g. Engagement Resources needs a Project Manager and Project Lead)' })
+  allowsEmpty: boolean;
+
+  @Prop({ required: true, default: false })
+  @Field({ description: 'Staff flag: when true, the customer must type their initials for this section before they can sign' })
+  requiresInitials: boolean;
 }
 
 /**
@@ -194,6 +202,22 @@ export class SowVersionInputs {
   customerCategory?: string;
 }
 
+@Schema({ _id: false })
+@ObjectType({ description: 'Initials a signer typed for one section flagged as requiring them' })
+export class SowSectionInitial {
+  @Prop({ required: true })
+  @Field({ description: 'Section key the initials were given for' })
+  key: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '', description: "Section's label at the time it was signed, for display without a fields lookup" })
+  label: string;
+
+  @Prop({ required: true })
+  @Field({ description: 'Initials as typed by the signer' })
+  initials: string;
+}
+
 /**
  * A customer's or staff member's assent. Consent is per field-kind: the reader
  * ticks one box for the calculated figures, one for the standard prose, one for
@@ -213,6 +237,10 @@ export class SowConsent {
   @Prop({ type: [String], default: [] })
   @Field(() => [SowFieldKind], { description: 'Field kinds the signer explicitly acknowledged' })
   consentedGroups: SowFieldKind[];
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [SowSectionInitial], { description: 'Initials given for each section staff flagged requiresInitials' })
+  sectionInitials: SowSectionInitial[];
 
   @Prop({ required: false })
   @Field({ nullable: true, description: 'Keycloak sub of the signer' })
@@ -240,8 +268,15 @@ export class SowVersion {
   sowId: string;
 
   @Prop({ required: true })
-  @Field(() => Int, { description: 'Monotonic per SOW, starting at 1' })
+  @Field(() => Int, {
+    description:
+      'Sortable, unique key, and the encoding of the human-facing "<sent-count>.<sub-revision>" label in one number: major*1000 + minor. See displayVersion for the decoded "1.2" form — SowVersionService.encodeVersionNumber/decodeVersionNumber own the encoding.'
+  })
   versionNumber: number;
+
+  // displayVersion has no class property: it is resolved purely from
+  // versionNumber by SowVersionFieldsResolver, so it can never be forgotten on
+  // one write path and present on another.
 
   @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
   @Field(() => [SowField], { description: 'The document, in order' })

--- a/src/sow/sow-version.model.ts
+++ b/src/sow/sow-version.model.ts
@@ -127,6 +127,10 @@ export class SowVersionService {
   @Prop({ required: true })
   @Field(() => Float)
   cost: number;
+
+  @Prop({ required: false })
+  @Field(() => Float, { nullable: true, description: 'The run-count multiplier baked into cost, if the underlying node has one. Informational only — Fee Schedule has no control to edit it.' })
+  runCount?: number;
 }
 
 @Schema({ _id: false })

--- a/src/sow/sow-version.model.ts
+++ b/src/sow/sow-version.model.ts
@@ -1,0 +1,301 @@
+import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+import mongoose from 'mongoose';
+import { Field, ObjectType, ID, Int, Float, registerEnumType } from '@nestjs/graphql';
+import { SOWStatus, SOWAdjustmentType } from './sow.model';
+
+/**
+ * A SOW version is an immutable snapshot of the document. Save, send, sign,
+ * finalize and cancel each insert a new one; nothing is ever updated in place.
+ *
+ * Two pointers on the parent SOW decide what each audience sees:
+ *   currentVersionNumber — the latest version, what staff edit
+ *   activeVersionNumber  — the version in force with the customer
+ * They differ whenever staff are drafting changes to an already-issued SOW, which
+ * is why a draft never invalidates a signature.
+ */
+
+export enum SowFieldKind {
+  /** Generated from structured inputs (dates, staff, pricing). */
+  CALCULATED = 'CALCULATED',
+  /** Boilerplate prose with a default staff can edit. */
+  PROSE = 'PROSE',
+  /** Added ad hoc by staff on this SOW. */
+  CUSTOM = 'CUSTOM'
+}
+registerEnumType(SowFieldKind, { name: 'SowFieldKind' });
+
+@Schema({ _id: false })
+@ObjectType({ description: 'One section of the SOW document' })
+export class SowField {
+  @Prop({ required: true })
+  @Field({ description: 'Stable identifier, e.g. "feeSchedule" or "custom-<uuid>"' })
+  key: string;
+
+  @Prop({ required: true })
+  @Field({ description: 'Heading shown above this section' })
+  label: string;
+
+  @Prop({ required: true })
+  @Field(() => SowFieldKind)
+  kind: SowFieldKind;
+
+  @Prop({ required: true })
+  @Field(() => Int, { description: 'Document order; ascending' })
+  order: number;
+
+  @Prop({ required: true })
+  @Field({ description: 'Text shown to the reader. Plain text; lines beginning "- " are bullets.' })
+  value: string;
+
+  @Prop({ required: false })
+  @Field({
+    description: 'What the generator produced for this field, kept alongside any override so "revert to calculated" has a current target.',
+    nullable: true
+  })
+  calculatedValue?: string;
+
+  @Prop({ required: true, default: false })
+  @Field({ description: 'True when a staff member replaced the generated text by hand' })
+  isOverridden: boolean;
+
+  @Prop({ required: true, default: true })
+  @Field({ description: 'When false the section is retained but hidden from the customer, the PDF and consent' })
+  isEnabled: boolean;
+
+  @Prop({ required: true, default: true })
+  @Field({
+    description: 'False on fields whose text carries figures another system bills from (Fee Schedule), where free-text editing would let the document disagree with the invoice'
+  })
+  allowsTextOverride: boolean;
+}
+
+/**
+ * What the preview query returns: the generated text for a field, and nothing
+ * else. The editor holds its own value / isOverridden / isEnabled — including
+ * unsaved edits the server has never seen — so returning whole rows here would
+ * overwrite work in progress every time a dropdown changed.
+ */
+@ObjectType({ description: 'Generated text for one field, for live preview while editing' })
+export class SowCalculatedValue {
+  @Field()
+  key: string;
+
+  @Field()
+  calculatedValue: string;
+}
+
+@Schema({ _id: false })
+@ObjectType({ description: 'A single period of performance; a SOW may have several, non-consecutive or retroactive' })
+export class SowPeriod {
+  @Prop({ required: true })
+  @Field()
+  startDate: Date;
+
+  @Prop({ required: true })
+  @Field(() => Int)
+  durationDays: number;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Optional name, e.g. "Phase 1"' })
+  label?: string;
+}
+
+@Schema({ _id: false })
+@ObjectType({ description: 'Service line as frozen into this version' })
+export class SowVersionService {
+  @Prop({ required: true })
+  @Field(() => ID)
+  serviceId: string;
+
+  @Prop({ required: true })
+  @Field()
+  name: string;
+
+  @Prop({ required: true, default: '' })
+  @Field()
+  description: string;
+
+  @Prop({ required: true })
+  @Field(() => Float)
+  cost: number;
+}
+
+@Schema({ _id: false })
+@ObjectType({ description: 'Pricing adjustment as frozen into this version' })
+export class SowVersionAdjustment {
+  @Prop({ required: true })
+  @Field(() => SOWAdjustmentType)
+  type: SOWAdjustmentType;
+
+  @Prop({ required: true })
+  @Field()
+  description: string;
+
+  @Prop({ required: true })
+  @Field(() => Float)
+  amount: number;
+
+  @Prop({ required: false })
+  @Field({ nullable: true })
+  reason?: string;
+}
+
+/**
+ * The structured drivers behind the calculated fields, frozen at save time.
+ * Reloading a version into the editor restores these controls, and comparing them
+ * against the SOW's live billing core is how documentStale is decided.
+ */
+@Schema({ _id: false })
+@ObjectType({ description: 'Structured inputs that generated this version' })
+export class SowVersionInputs {
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '' })
+  projectManager: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '' })
+  projectLead: string;
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [SowPeriod])
+  periods: SowPeriod[];
+
+  @Prop({ required: false })
+  @Field({ nullable: true })
+  sowTitle?: string;
+
+  @Prop({ type: [String], default: [] })
+  @Field(() => [String])
+  scopeOfWork: string[];
+
+  @Prop({ type: [String], default: [] })
+  @Field(() => [String])
+  deliverables: string[];
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [SowVersionService])
+  services: SowVersionService[];
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [SowVersionAdjustment])
+  adjustments: SowVersionAdjustment[];
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Float)
+  baseCost: number;
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Float)
+  totalCost: number;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Pricing category of the job at the time this version was written' })
+  customerCategory?: string;
+}
+
+/**
+ * A customer's or staff member's assent. Consent is per field-kind: the reader
+ * ticks one box for the calculated figures, one for the standard prose, one for
+ * any custom sections, so what they agreed to is recorded rather than implied.
+ */
+@Schema({ _id: false })
+@ObjectType({ description: 'Signature captured as typed name plus per-group consent' })
+export class SowConsent {
+  @Prop({ required: true })
+  @Field()
+  name: string;
+
+  @Prop({ required: true })
+  @Field()
+  signedAt: Date;
+
+  @Prop({ type: [String], default: [] })
+  @Field(() => [SowFieldKind], { description: 'Field kinds the signer explicitly acknowledged' })
+  consentedGroups: SowFieldKind[];
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Keycloak sub of the signer' })
+  bySub?: string;
+
+  @Prop({ required: false })
+  @Field({
+    nullable: true,
+    description: 'Drawn signature carried over from the pre-versioning flow, so migrated SOWs still export with the image the customer actually drew. Never set for new signatures.'
+  })
+  legacySignatureDataUrl?: string;
+}
+
+@Schema({ collection: 'sow_versions' })
+@ObjectType({ description: 'Immutable snapshot of a Statement of Work' })
+export class SowVersion {
+  @Field(() => ID, { name: 'id' })
+  _id: string;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'SOW', required: true })
+  sow: mongoose.Types.ObjectId;
+
+  @Prop({ required: true })
+  @Field(() => ID, { description: 'Parent SOW id (string mirror, for querying)' })
+  sowId: string;
+
+  @Prop({ required: true })
+  @Field(() => Int, { description: 'Monotonic per SOW, starting at 1' })
+  versionNumber: number;
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [SowField], { description: 'The document, in order' })
+  fields: SowField[];
+
+  @Prop({ type: mongoose.Schema.Types.Mixed, required: true })
+  @Field(() => SowVersionInputs)
+  inputs: SowVersionInputs;
+
+  @Prop({ required: true, default: SOWStatus.DRAFT })
+  @Field(() => SOWStatus)
+  status: SOWStatus;
+
+  @Prop({ required: true, default: false })
+  @Field({ description: 'True once this version has been issued: sent, signed, finalized or cancelled' })
+  visibleToCustomer: boolean;
+
+  @Prop({ required: false })
+  @Field({ nullable: true })
+  sentToCustomerAt?: Date;
+
+  @Prop({ type: mongoose.Schema.Types.Mixed, required: false })
+  @Field(() => SowConsent, { nullable: true })
+  clientSignature?: SowConsent;
+
+  @Prop({ type: mongoose.Schema.Types.Mixed, required: false })
+  @Field(() => SowConsent, { nullable: true, description: 'BU countersignature captured at finalize' })
+  staffSignature?: SowConsent;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Optional note describing what changed' })
+  note?: string;
+
+  @Prop({ required: true, default: false })
+  @Field({ description: 'Unsent draft the staff abandoned; hidden from history by default' })
+  isDiscarded: boolean;
+
+  @Prop({ required: true })
+  @Field({ description: 'Keycloak sub or email of the author' })
+  createdBy: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '', description: 'Display name of the author, resolved at write time' })
+  createdByName: string;
+
+  @Prop({ required: true, default: () => new Date() })
+  @Field()
+  createdAt: Date;
+}
+
+export type SowVersionDocument = SowVersion & Document;
+export const SowVersionSchema = SchemaFactory.createForClass(SowVersion);
+
+// One version number per SOW; also the index that serves history listing (newest first).
+SowVersionSchema.index({ sowId: 1, versionNumber: -1 }, { unique: true });
+// Customer-visible history.
+SowVersionSchema.index({ sowId: 1, visibleToCustomer: 1 });

--- a/src/sow/sow-version.service.spec.ts
+++ b/src/sow/sow-version.service.spec.ts
@@ -128,3 +128,34 @@ describe('billingFingerprint', () => {
     expect(SowVersionService.billingFingerprint(changed)).toBe(SowVersionService.billingFingerprint(base));
   });
 });
+
+describe('version number encoding', () => {
+  it('encodes major/minor into a single number, ordered exactly like major.minor would be', () => {
+    expect(SowVersionService.encodeVersionNumber(0, 1)).toBe(1);
+    expect(SowVersionService.encodeVersionNumber(0, 2)).toBe(2);
+    expect(SowVersionService.encodeVersionNumber(1, 0)).toBe(1000);
+    expect(SowVersionService.encodeVersionNumber(1, 2)).toBe(1002);
+    expect(SowVersionService.encodeVersionNumber(2, 0)).toBe(2000);
+
+    const encoded = [
+      SowVersionService.encodeVersionNumber(0, 1),
+      SowVersionService.encodeVersionNumber(0, 2),
+      SowVersionService.encodeVersionNumber(1, 0),
+      SowVersionService.encodeVersionNumber(1, 2),
+      SowVersionService.encodeVersionNumber(2, 0)
+    ];
+    expect([...encoded].sort((a, b) => a - b)).toEqual(encoded);
+  });
+
+  it('decodes back to the major/minor it was built from', () => {
+    expect(SowVersionService.decodeVersionNumber(1)).toEqual({ major: 0, minor: 1 });
+    expect(SowVersionService.decodeVersionNumber(1002)).toEqual({ major: 1, minor: 2 });
+    expect(SowVersionService.decodeVersionNumber(2000)).toEqual({ major: 2, minor: 0 });
+  });
+
+  it('formats the human label as major.minor', () => {
+    expect(SowVersionService.displayVersionLabel(1)).toBe('0.1');
+    expect(SowVersionService.displayVersionLabel(1000)).toBe('1.0');
+    expect(SowVersionService.displayVersionLabel(1002)).toBe('1.2');
+  });
+});

--- a/src/sow/sow-version.service.spec.ts
+++ b/src/sow/sow-version.service.spec.ts
@@ -1,0 +1,130 @@
+import { SowVersionService } from './sow-version.service';
+import { SOW, SOWAdjustmentType } from './sow.model';
+
+function sow(overrides: Partial<SOW> = {}): SOW {
+  return {
+    sowNumber: 'SOW 001',
+    date: new Date('2026-03-01T00:00:00Z'),
+    jobId: 'job-1',
+    jobName: 'Plasmid prep',
+    clientName: 'Jane Rivera',
+    clientEmail: 'jane@lab.org',
+    clientInstitution: 'Example University',
+    scopeOfWork: ['Run NGS'],
+    deliverables: ['FASTQ'],
+    services: [{ _id: 's1', serviceId: 's1', name: 'NGS', description: 'seq', cost: 350, category: 'molecular-biology' }],
+    timeline: { startDate: new Date('2026-03-03T00:00:00Z'), endDate: new Date('2026-03-16T00:00:00Z'), duration: '14 days' },
+    resources: { projectManager: 'Courtney Tretheway', projectLead: 'Kristen Sheldon' },
+    pricing: { baseCost: 350, adjustments: [], totalCost: 350 },
+    ...overrides
+  } as unknown as SOW;
+}
+
+describe('parseDurationDays', () => {
+  const p = SowVersionService.parseDurationDays;
+
+  it('reads the day count out of the free text the old flow stored', () => {
+    expect(p('14 days')).toBe(14);
+    expect(p('1 day')).toBe(1);
+    expect(p('7')).toBe(7);
+  });
+
+  it('converts weeks and months', () => {
+    expect(p('5 weeks')).toBe(35);
+    expect(p('2 months')).toBe(60);
+  });
+
+  it('accepts a number', () => {
+    expect(p(21)).toBe(21);
+  });
+
+  it('falls back to zero on junk rather than NaN', () => {
+    expect(p('soon')).toBe(0);
+    expect(p(undefined)).toBe(0);
+    expect(p(null)).toBe(0);
+    expect(p('')).toBe(0);
+  });
+});
+
+describe('deriveInputs', () => {
+  it('turns the single stored timeline into one period', () => {
+    const inputs = SowVersionService.deriveInputs(sow(), { customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC' });
+    expect(inputs.periods).toHaveLength(1);
+    expect(inputs.periods[0].durationDays).toBe(14);
+    expect(inputs.periods[0].startDate.toISOString().slice(0, 10)).toBe('2026-03-03');
+  });
+
+  it('carries staff, scope, deliverables and pricing across', () => {
+    const inputs = SowVersionService.deriveInputs(sow(), null);
+    expect(inputs.projectManager).toBe('Courtney Tretheway');
+    expect(inputs.scopeOfWork).toEqual(['Run NGS']);
+    expect(inputs.services[0]).toMatchObject({ serviceId: 's1', name: 'NGS', cost: 350 });
+    expect(inputs.baseCost).toBe(350);
+  });
+
+  it('drops SPECIAL_TERM adjustments, which never affected any total', () => {
+    const withSpecial = sow({
+      pricing: {
+        baseCost: 350,
+        totalCost: 350,
+        adjustments: [
+          { _id: 'a1', type: SOWAdjustmentType.SPECIAL_TERM, description: 'Materials returned in 30 days', amount: 75 },
+          { _id: 'a2', type: SOWAdjustmentType.ADDITIONAL_COST, description: 'Rush', amount: 120 }
+        ]
+      }
+    } as any);
+
+    const inputs = SowVersionService.deriveInputs(withSpecial, null);
+    expect(inputs.adjustments).toHaveLength(1);
+    expect(inputs.adjustments[0].type).toBe(SOWAdjustmentType.ADDITIONAL_COST);
+  });
+
+  it('survives a SOW with missing optional structures', () => {
+    const bare = { jobId: 'j', sowNumber: 'SOW 002' } as unknown as SOW;
+    const inputs = SowVersionService.deriveInputs(bare, null);
+    expect(inputs.periods).toEqual([]);
+    expect(inputs.services).toEqual([]);
+    expect(inputs.baseCost).toBe(0);
+  });
+});
+
+describe('billingFingerprint', () => {
+  const base = SowVersionService.deriveInputs(sow(), { customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC' });
+
+  it('is stable for unchanged billing data', () => {
+    const again = SowVersionService.deriveInputs(sow(), { customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC' });
+    expect(SowVersionService.billingFingerprint(again)).toBe(SowVersionService.billingFingerprint(base));
+  });
+
+  it('changes when a service cost changes', () => {
+    const changed = SowVersionService.deriveInputs(
+      sow({ services: [{ _id: 's1', serviceId: 's1', name: 'NGS', description: 'seq', cost: 400, category: 'x' }], pricing: { baseCost: 400, adjustments: [], totalCost: 400 } } as any),
+      { customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC' }
+    );
+    expect(SowVersionService.billingFingerprint(changed)).not.toBe(SowVersionService.billingFingerprint(base));
+  });
+
+  it('changes when a service is added', () => {
+    const changed = SowVersionService.deriveInputs(
+      sow({
+        services: [
+          { _id: 's1', serviceId: 's1', name: 'NGS', description: 'seq', cost: 350, category: 'x' },
+          { _id: 's2', serviceId: 's2', name: 'PCR', description: '', cost: 20, category: 'x' }
+        ],
+        pricing: { baseCost: 370, adjustments: [], totalCost: 370 }
+      } as any),
+      { customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC' }
+    );
+    expect(SowVersionService.billingFingerprint(changed)).not.toBe(SowVersionService.billingFingerprint(base));
+  });
+
+  it('changes when the pricing category changes', () => {
+    const changed = SowVersionService.deriveInputs(sow(), { customerCategory: 'INTERNAL_CUSTOMERS' });
+    expect(SowVersionService.billingFingerprint(changed)).not.toBe(SowVersionService.billingFingerprint(base));
+  });
+
+  it('ignores changes that do not affect the fee schedule', () => {
+    const changed = SowVersionService.deriveInputs(sow({ resources: { projectManager: 'Someone Else', projectLead: 'X' } } as any), { customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC' });
+    expect(SowVersionService.billingFingerprint(changed)).toBe(SowVersionService.billingFingerprint(base));
+  });
+});

--- a/src/sow/sow-version.service.ts
+++ b/src/sow/sow-version.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Inject, forwardRef, BadRequestException, ConflictException, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { Injectable, Logger, Inject, forwardRef, BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import mongoose from 'mongoose';
@@ -367,7 +367,8 @@ export class SowVersionService {
    * lets staff iterate on a signed SOW without invalidating the signature.
    */
   async saveVersion(sowId: string, input: SaveSowVersionInput, author: { sub: string; name: string }): Promise<SowVersionDocument> {
-    const sow = await this.requireSow(sowId);
+    // Called for the 404 it throws: nothing below reads the SOW itself.
+    await this.requireSow(sowId);
     const current = await this.getCurrentVersion(sowId);
     const currentNumber = current?.versionNumber ?? 0;
 

--- a/src/sow/sow-version.service.ts
+++ b/src/sow/sow-version.service.ts
@@ -1,0 +1,530 @@
+import { Injectable, Logger, Inject, forwardRef, BadRequestException, ConflictException, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import mongoose from 'mongoose';
+import { SOW, SOWDocument, SOWStatus, SOWAdjustmentType } from './sow.model';
+import { SowVersion, SowVersionDocument, SowVersionInputs, SowField, SowFieldKind, SowPeriod, SowConsent } from './sow-version.model';
+import { buildCalculatedFields, calculateFieldValues, normalizeIncomingFields, SowDocumentContext } from './sow-field-calculator';
+import { SOWService } from './sow.service';
+import { SaveSowVersionInput } from './dto/save-sow-version.input';
+import { SignSowInput } from './dto/sign-sow.input';
+import { User } from '../auth/user.interface';
+
+/**
+ * Inputs as they arrive from the editor: the same shape as SowVersionInputs but
+ * with everything optional, since a preview may be requested mid-edit before all
+ * controls have been touched.
+ */
+export type SowInputsLike = Partial<Omit<SowVersionInputs, 'services' | 'periods'>> & {
+  services?: Array<{ serviceId: string; name: string; description?: string; cost: number }>;
+  periods?: Array<{ startDate: Date; durationDays: number; label?: string }>;
+};
+
+/**
+ * Creation, transitions and bookkeeping for immutable SOW versions.
+ *
+ * Every operation that changes the document appends a version; nothing is ever
+ * updated in place. Which version each audience sees is decided by two pointers
+ * on the parent SOW — currentVersionNumber (staff) and activeVersionNumber
+ * (customer) — so staff can iterate on a draft above a signed version without
+ * invalidating the signature.
+ */
+@Injectable()
+export class SowVersionService {
+  private readonly logger = new Logger(SowVersionService.name);
+
+  constructor(
+    @InjectModel(SowVersion.name) private readonly versionModel: Model<SowVersionDocument>,
+    @InjectModel(SOW.name) private readonly sowModel: Model<SOWDocument>,
+    @Inject(forwardRef(() => SOWService)) private readonly sowService: SOWService
+  ) {}
+
+  /**
+   * Parses the free-text duration the old flow stored ("14 days", "5 weeks") into
+   * whole days. Weeks are the only non-day unit that ever appeared; anything
+   * unrecognised falls back to the leading integer, then to zero.
+   */
+  static parseDurationDays(duration: unknown): number {
+    if (typeof duration === 'number' && Number.isFinite(duration)) return Math.max(0, Math.round(duration));
+    if (typeof duration !== 'string') return 0;
+    const match = duration.trim().match(/^(\d+(?:\.\d+)?)\s*(\w+)?/);
+    if (!match) return 0;
+    const n = Number(match[1]);
+    if (!Number.isFinite(n)) return 0;
+    const unit = (match[2] ?? 'day').toLowerCase();
+    if (unit.startsWith('week')) return Math.round(n * 7);
+    if (unit.startsWith('month')) return Math.round(n * 30);
+    return Math.round(n);
+  }
+
+  /**
+   * The structured drivers behind a SOW's document, read off the SOW itself.
+   * Used to seed version 1 and, on later saves, as the baseline the editor loads.
+   *
+   * SPECIAL_TERM adjustments are dropped: they contributed nothing to any total
+   * (see SOWService.calculateAdjustmentsTotal), so an amount typed against one
+   * silently vanished. The migration preserves their wording as a custom field.
+   */
+  static deriveInputs(sow: SOW, job?: { customerCategory?: string } | null): SowVersionInputs {
+    const timeline = sow.timeline ?? ({} as any);
+    const durationDays = SowVersionService.parseDurationDays(timeline.duration);
+    const periods: SowPeriod[] = timeline.startDate ? [{ startDate: new Date(timeline.startDate), durationDays, label: undefined }] : [];
+
+    return {
+      projectManager: sow.resources?.projectManager ?? '',
+      projectLead: sow.resources?.projectLead ?? '',
+      periods,
+      sowTitle: sow.sowTitle ?? '',
+      scopeOfWork: sow.scopeOfWork ?? [],
+      deliverables: sow.deliverables ?? [],
+      services: (sow.services ?? []).map((s) => ({
+        serviceId: String(s.serviceId ?? s._id ?? ''),
+        name: s.name ?? 'Service',
+        description: s.description ?? '',
+        cost: Number(s.cost ?? 0)
+      })),
+      adjustments: (sow.pricing?.adjustments ?? [])
+        .filter((a) => a.type !== SOWAdjustmentType.SPECIAL_TERM)
+        .map((a) => ({ type: a.type, description: a.description ?? '', amount: Number(a.amount ?? 0), reason: a.reason })),
+      baseCost: Number(sow.pricing?.baseCost ?? 0),
+      totalCost: Number(sow.pricing?.totalCost ?? 0),
+      customerCategory: job?.customerCategory
+    };
+  }
+
+  static buildContext(sow: SOW, job?: { jobId?: string; name?: string } | null): SowDocumentContext {
+    return {
+      sowNumber: sow.sowNumber,
+      date: sow.date ? new Date(sow.date) : undefined,
+      jobDisplayId: (job as any)?.jobId ?? sow.jobId,
+      jobName: sow.jobName,
+      clientName: sow.clientName,
+      clientEmail: sow.clientEmail,
+      clientInstitution: sow.clientInstitution,
+      clientAddress: sow.clientAddress
+    };
+  }
+
+  /**
+   * What the Fee Schedule depends on. Two versions with the same fingerprint
+   * would render the same figures, so a change here — and only here — means the
+   * document has fallen behind the billing core.
+   */
+  static billingFingerprint(inputs: Pick<SowVersionInputs, 'services' | 'adjustments' | 'baseCost' | 'totalCost' | 'customerCategory'>): string {
+    const services = (inputs.services ?? []).map((s) => `${s.serviceId}:${s.name}:${Number(s.cost).toFixed(2)}`).join('|');
+    const adjustments = (inputs.adjustments ?? []).map((a) => `${a.type}:${a.description}:${Number(a.amount).toFixed(2)}`).join('|');
+    return [services, adjustments, Number(inputs.baseCost ?? 0).toFixed(2), Number(inputs.totalCost ?? 0).toFixed(2), inputs.customerCategory ?? ''].join('#');
+  }
+
+  /**
+   * The newest version that still counts — what the editor opens and what the
+   * transitions act on. Discarded drafts are skipped: after abandoning one, staff
+   * must land back on real content rather than the draft they just threw away.
+   */
+  async getCurrentVersion(sowId: string): Promise<SowVersionDocument | null> {
+    return this.versionModel
+      .findOne({ sowId: String(sowId), isDiscarded: false })
+      .sort({ versionNumber: -1 })
+      .exec();
+  }
+
+  /**
+   * Next free version number, counting discarded drafts.
+   *
+   * Numbers are never reused. Discarding v4 rolls the current pointer back to v3,
+   * but the next save must still be v5 — reusing 4 would collide with the
+   * discarded row on the unique {sowId, versionNumber} index, and would make the
+   * history read as though the abandoned draft had been edited into existence.
+   */
+  private async nextVersionNumber(sowId: string): Promise<number> {
+    const highest = await this.versionModel
+      .findOne({ sowId: String(sowId) })
+      .sort({ versionNumber: -1 })
+      .exec();
+    return (highest?.versionNumber ?? 0) + 1;
+  }
+
+  async getVersion(sowId: string, versionNumber: number): Promise<SowVersionDocument | null> {
+    return this.versionModel.findOne({ sowId: String(sowId), versionNumber }).exec();
+  }
+
+  async listVersions(sowId: string, opts: { visibleOnly?: boolean; includeDiscarded?: boolean } = {}): Promise<SowVersionDocument[]> {
+    const filter: Record<string, unknown> = { sowId: String(sowId) };
+    if (opts.visibleOnly) filter.visibleToCustomer = true;
+    if (!opts.includeDiscarded) filter.isDiscarded = false;
+    return this.versionModel.find(filter).sort({ versionNumber: -1 }).exec();
+  }
+
+  /**
+   * Writes version 1 for a SOW that has none. Idempotent: returns the existing
+   * current version if one is already present, so callers on the create path and
+   * the migration can both use it without racing.
+   */
+  async createInitialVersion(
+    sow: SOW,
+    job: { customerCategory?: string; jobId?: string; name?: string } | null,
+    createdBy: string,
+    opts: { fields?: SowField[]; status?: SOWStatus; visibleToCustomer?: boolean; note?: string } = {}
+  ): Promise<SowVersionDocument> {
+    const sowId = String((sow as any)._id);
+    const existing = await this.getCurrentVersion(sowId);
+    if (existing) return existing;
+
+    const inputs = SowVersionService.deriveInputs(sow, job);
+    const ctx = SowVersionService.buildContext(sow, job);
+    const fields = opts.fields ?? buildCalculatedFields(inputs, ctx);
+    const status = opts.status ?? SOWStatus.DRAFT;
+    const visibleToCustomer = opts.visibleToCustomer ?? status !== SOWStatus.DRAFT;
+
+    const created = await this.versionModel.create({
+      sow: new mongoose.Types.ObjectId(sowId),
+      sowId,
+      versionNumber: 1,
+      fields,
+      inputs,
+      status,
+      visibleToCustomer,
+      note: opts.note,
+      isDiscarded: false,
+      createdBy,
+      createdByName: createdBy,
+      createdAt: new Date()
+    });
+
+    await this.sowModel
+      .findByIdAndUpdate(sowId, {
+        $set: {
+          currentVersionNumber: 1,
+          activeVersionNumber: visibleToCustomer ? 1 : 0,
+          documentStale: false
+        }
+      })
+      .exec();
+
+    return created;
+  }
+
+  // -------------------------------------------------------------------------
+  // Transitions. Each appends a version; none mutates an existing one.
+  // -------------------------------------------------------------------------
+
+  private async requireSow(sowId: string): Promise<SOWDocument> {
+    const sow = await this.sowModel.findById(sowId).exec();
+    if (!sow) throw new NotFoundException(`SOW with ID ${sowId} not found`);
+    return sow;
+  }
+
+  /**
+   * Appends a version cloned from `from`, changing only status and the fields the
+   * caller names. Used by send / sign / finalize / cancel, which record an event
+   * rather than a content change — so their diff against the previous version is
+   * empty and the history reads as a clean audit trail.
+   */
+  private async appendVersion(
+    sow: SOWDocument,
+    from: SowVersionDocument,
+    changes: { status: SOWStatus; note?: string; clientSignature?: SowConsent; staffSignature?: SowConsent; sentToCustomerAt?: Date; makeActive: boolean },
+    author: { sub: string; name: string }
+  ): Promise<SowVersionDocument> {
+    const sowId = String(sow._id);
+    const versionNumber = await this.nextVersionNumber(sowId);
+
+    const created = await this.versionModel.create({
+      sow: new mongoose.Types.ObjectId(sowId),
+      sowId,
+      versionNumber,
+      fields: from.fields,
+      inputs: from.inputs,
+      status: changes.status,
+      visibleToCustomer: changes.makeActive,
+      sentToCustomerAt: changes.sentToCustomerAt ?? from.sentToCustomerAt,
+      clientSignature: changes.clientSignature ?? from.clientSignature,
+      staffSignature: changes.staffSignature ?? from.staffSignature,
+      note: changes.note,
+      isDiscarded: false,
+      createdBy: author.sub,
+      createdByName: author.name,
+      createdAt: new Date()
+    });
+
+    const update: Record<string, unknown> = { currentVersionNumber: versionNumber, status: changes.status };
+    if (changes.makeActive) update.activeVersionNumber = versionNumber;
+    await this.sowModel.findByIdAndUpdate(sowId, { $set: update }).exec();
+
+    return created;
+  }
+
+  /**
+   * Recomputes the generated text for a set of in-progress inputs, without
+   * touching the database.
+   *
+   * Billing figures come from the stored SOW rather than the request, so a
+   * preview cannot be used to display prices the billing core does not hold.
+   * Returns generated values only; the editor owns everything else.
+   */
+  async previewCalculatedValues(sowId: string, inputs: SowInputsLike): Promise<Array<{ key: string; calculatedValue: string }>> {
+    const sow = await this.requireSow(sowId);
+    const job = await this.sowService.getJobForSow(sow);
+    const stored = SowVersionService.deriveInputs(sow, job);
+
+    const merged: SowVersionInputs = {
+      ...stored,
+      projectManager: inputs.projectManager ?? stored.projectManager,
+      projectLead: inputs.projectLead ?? stored.projectLead,
+      periods: (inputs.periods ?? stored.periods ?? []).map((p) => ({ startDate: new Date(p.startDate), durationDays: p.durationDays, label: p.label })),
+      sowTitle: inputs.sowTitle ?? stored.sowTitle,
+      scopeOfWork: inputs.scopeOfWork ?? stored.scopeOfWork,
+      deliverables: inputs.deliverables ?? stored.deliverables,
+      // Unsaved billing edits still need to show in the preview, but only as
+      // costs applied to lines the SOW already has — a preview cannot invent one.
+      services: (stored.services ?? []).map((s) => {
+        const edited = (inputs.services ?? []).find((x) => String(x.serviceId) === String(s.serviceId));
+        return edited && Number.isFinite(edited.cost) && edited.cost >= 0 ? { ...s, cost: edited.cost } : s;
+      }),
+      adjustments: (inputs.adjustments ?? stored.adjustments ?? []).filter((a) => a.type !== SOWAdjustmentType.SPECIAL_TERM)
+    };
+
+    merged.baseCost = (merged.services ?? []).reduce((sum, s) => sum + (Number(s.cost) || 0), 0);
+    merged.totalCost = (merged.adjustments ?? []).reduce(
+      (sum, a) => sum + (a.type === SOWAdjustmentType.DISCOUNT ? -Math.abs(Number(a.amount) || 0) : Math.abs(Number(a.amount) || 0)),
+      merged.baseCost
+    );
+
+    const ctx = SowVersionService.buildContext(sow, job);
+    const values = calculateFieldValues(merged, ctx);
+    return Object.entries(values).map(([key, calculatedValue]) => ({ key, calculatedValue }));
+  }
+
+  /** The version the customer is bound by, or null before anything is issued. */
+  async getActiveVersion(sowId: string): Promise<SowVersionDocument | null> {
+    const sow = await this.requireSow(sowId);
+    if (!sow.activeVersionNumber) return null;
+    return this.getVersion(sowId, sow.activeVersionNumber);
+  }
+
+  /**
+   * Saves staff edits as a new DRAFT.
+   *
+   * Never moves activeVersionNumber: a draft above a signed or finalized version
+   * leaves that version in force until someone explicitly sends it, which is what
+   * lets staff iterate on a signed SOW without invalidating the signature.
+   */
+  async saveVersion(sowId: string, input: SaveSowVersionInput, author: { sub: string; name: string }): Promise<SowVersionDocument> {
+    const sow = await this.requireSow(sowId);
+    const current = await this.getCurrentVersion(sowId);
+    const currentNumber = current?.versionNumber ?? 0;
+
+    if (input.baseVersionNumber !== currentNumber) {
+      throw new ConflictException(`This SOW has moved on since you opened it (you have v${input.baseVersionNumber}, it is now v${currentNumber}). Reload to see the newer version before saving.`);
+    }
+
+    // Billing figures first: the fee schedule text is generated from the billing
+    // core, so it has to be written before the document is composed or the saved
+    // text would describe the previous prices.
+    const hasBillingEdits = (input.inputs.services ?? []).length > 0 || input.inputs.adjustments !== undefined;
+    if (hasBillingEdits) {
+      await this.sowService.applyDocumentBilling(sowId, {
+        serviceCosts: (input.inputs.services ?? []).map((s) => ({ serviceId: s.serviceId, cost: s.cost })),
+        adjustments: (input.inputs.adjustments ?? []).map((a) => ({ type: a.type, description: a.description, amount: a.amount, reason: a.reason })) as any
+      });
+    }
+
+    const fresh = await this.requireSow(sowId);
+    const job = await this.sowService.getJobForSow(fresh);
+
+    // Editable inputs come from the request; billing figures are read back from
+    // the SOW after the write above, so the version records what was actually
+    // stored rather than what the client claimed.
+    const derived = SowVersionService.deriveInputs(fresh, job);
+    const inputs: SowVersionInputs = {
+      ...derived,
+      projectManager: input.inputs.projectManager ?? '',
+      projectLead: input.inputs.projectLead ?? '',
+      periods: (input.inputs.periods ?? []).map((p) => ({ startDate: new Date(p.startDate), durationDays: p.durationDays, label: p.label })),
+      sowTitle: input.inputs.sowTitle ?? '',
+      scopeOfWork: input.inputs.scopeOfWork ?? [],
+      deliverables: input.inputs.deliverables ?? []
+    };
+
+    const ctx = SowVersionService.buildContext(fresh, job);
+    const fields = normalizeIncomingFields(
+      (input.fields ?? []).map((f) => ({ key: f.key, label: f.label ?? '', value: f.value ?? '', isEnabled: f.isEnabled !== false } as SowField)),
+      inputs,
+      ctx
+    );
+
+    const versionNumber = await this.nextVersionNumber(sowId);
+    const created = await this.versionModel.create({
+      sow: new mongoose.Types.ObjectId(sowId),
+      sowId,
+      versionNumber,
+      fields,
+      inputs,
+      status: SOWStatus.DRAFT,
+      visibleToCustomer: false,
+      isDiscarded: false,
+      note: input.note,
+      createdBy: author.sub,
+      createdByName: author.name,
+      createdAt: new Date()
+    });
+
+    await this.sowModel.findByIdAndUpdate(sowId, { $set: { currentVersionNumber: versionNumber, documentStale: false, updatedAt: new Date() } }).exec();
+
+    return created;
+  }
+
+  /**
+   * Marks an unsent draft as discarded. Drafts at or below the active pointer are
+   * part of the issued record and cannot be discarded.
+   */
+  async discardDraft(sowId: string, versionNumber: number): Promise<SOW> {
+    const sow = await this.requireSow(sowId);
+    const version = await this.getVersion(sowId, versionNumber);
+    if (!version) throw new NotFoundException(`Version ${versionNumber} not found`);
+
+    if (version.visibleToCustomer || versionNumber <= (sow.activeVersionNumber ?? 0)) {
+      throw new BadRequestException('Only unsent drafts above the active version can be discarded.');
+    }
+
+    // Discarding requires something to fall back to. On a SOW that has only ever
+    // had one draft there is nothing behind it, and discarding would leave the
+    // SOW with no document at all — no text for staff to open or customers to read.
+    const survivors = await this.versionModel.countDocuments({ sowId: String(sowId), isDiscarded: false, versionNumber: { $ne: versionNumber } }).exec();
+    if (survivors === 0) {
+      throw new BadRequestException('This is the only version of the document, so it cannot be discarded. Edit it instead.');
+    }
+
+    await this.versionModel.updateOne({ _id: version._id }, { $set: { isDiscarded: true } }).exec();
+
+    // Fall back to the newest surviving version so the editor reopens on real content.
+    const newest = await this.versionModel.findOne({ sowId, isDiscarded: false }).sort({ versionNumber: -1 }).exec();
+    const updated = await this.sowModel.findByIdAndUpdate(sowId, { $set: { currentVersionNumber: newest?.versionNumber ?? 0, status: newest?.status ?? SOWStatus.DRAFT } }, { new: true }).exec();
+
+    if (updated) await this.refreshDocumentStale(sowId);
+    return updated as SOW;
+  }
+
+  /** Issues the current draft to the customer. */
+  async sendToCustomer(sowId: string, author: { sub: string; name: string }): Promise<SowVersionDocument> {
+    const sow = await this.requireSow(sowId);
+    const current = await this.getCurrentVersion(sowId);
+    if (!current) throw new BadRequestException('This SOW has no document to send.');
+    if (current.status !== SOWStatus.DRAFT) throw new BadRequestException(`Only a draft can be sent; v${current.versionNumber} is ${current.status}.`);
+
+    const now = new Date();
+    return this.appendVersion(sow, current, { status: SOWStatus.SENT, sentToCustomerAt: now, makeActive: true, note: 'Sent to customer' }, author);
+  }
+
+  /**
+   * Records the customer's assent to the version in force.
+   *
+   * Requires the version the signer was looking at to still be the active one, so
+   * a stale tab cannot sign a document that has since been superseded.
+   */
+  async sign(sowId: string, input: SignSowInput, user: User): Promise<SowVersionDocument> {
+    const sow = await this.requireSow(sowId);
+    const active = await this.getActiveVersion(sowId);
+    if (!active) throw new BadRequestException('This SOW has not been sent to you yet.');
+
+    if (active.versionNumber !== input.versionNumber) {
+      throw new ConflictException(`You are viewing v${input.versionNumber} but v${active.versionNumber} is now in force. Reload to review the current version before signing.`);
+    }
+    if (active.status !== SOWStatus.SENT) {
+      throw new BadRequestException(`v${active.versionNumber} is ${active.status} and cannot be signed.`);
+    }
+    if (!input.name?.trim()) throw new BadRequestException('A typed name is required to sign.');
+
+    // Every group of sections present in the document must be acknowledged, so a
+    // client cannot sign while silently omitting, say, the custom sections.
+    const required = new Set((active.fields ?? []).filter((f) => f.isEnabled).map((f) => f.kind));
+    const consented = new Set(input.consentedGroups ?? []);
+    const missing = [...required].filter((k) => !consented.has(k));
+    if (missing.length > 0) {
+      throw new BadRequestException(`Please confirm every section before signing. Missing: ${missing.join(', ')}.`);
+    }
+
+    const signature: SowConsent = {
+      name: input.name.trim(),
+      signedAt: new Date(),
+      consentedGroups: [...consented] as SowFieldKind[],
+      bySub: user.sub
+    };
+
+    return this.appendVersion(sow, active, { status: SOWStatus.SIGNED, clientSignature: signature, makeActive: true, note: `Signed by ${signature.name}` }, { sub: user.sub, name: signature.name });
+  }
+
+  /** Staff countersignature; locks the signed version as the final record. */
+  async finalize(sowId: string, name: string, author: { sub: string; name: string }): Promise<SowVersionDocument> {
+    const sow = await this.requireSow(sowId);
+    const active = await this.getActiveVersion(sowId);
+    if (!active) throw new BadRequestException('This SOW has nothing to finalize.');
+    if (active.status !== SOWStatus.SIGNED) throw new BadRequestException(`Only a signed SOW can be finalized; v${active.versionNumber} is ${active.status}.`);
+    if (!name?.trim()) throw new BadRequestException('A name is required to countersign.');
+
+    const signature: SowConsent = {
+      name: name.trim(),
+      signedAt: new Date(),
+      consentedGroups: [SowFieldKind.CALCULATED, SowFieldKind.PROSE, SowFieldKind.CUSTOM],
+      bySub: author.sub
+    };
+
+    return this.appendVersion(sow, active, { status: SOWStatus.FINAL, staffSignature: signature, makeActive: true, note: `Countersigned by ${signature.name}` }, author);
+  }
+
+  async cancel(sowId: string, note: string | undefined, author: { sub: string; name: string }): Promise<SowVersionDocument> {
+    const sow = await this.requireSow(sowId);
+    const current = await this.getCurrentVersion(sowId);
+    if (!current) throw new BadRequestException('This SOW has no document to cancel.');
+    if (current.status === SOWStatus.CANCELLED) throw new BadRequestException('This SOW is already cancelled.');
+
+    return this.appendVersion(sow, current, { status: SOWStatus.CANCELLED, makeActive: true, note: note ?? 'Cancelled' }, author);
+  }
+
+  /** Appends to the question thread. Staff and the job owner may both post. */
+  async addQuestion(sowId: string, text: string, author: { sub: string; name: string; isStaff: boolean }): Promise<SOW> {
+    if (!text?.trim()) throw new BadRequestException('A question cannot be empty.');
+    const sow = await this.requireSow(sowId);
+
+    const question = {
+      authorSub: author.sub,
+      authorName: author.name,
+      isStaff: author.isStaff,
+      text: text.trim(),
+      versionNumber: sow.activeVersionNumber || sow.currentVersionNumber || undefined,
+      createdAt: new Date()
+    };
+
+    const updated = await this.sowModel.findByIdAndUpdate(sowId, { $push: { questions: question } }, { new: true }).exec();
+    return updated as SOW;
+  }
+
+  /**
+   * Recomputes documentStale after the billing core moves.
+   *
+   * Deliberately never touches a version. Rewriting the current version would
+   * mutate an immutable record; auto-creating one would spam the history on every
+   * workflow edit. Instead staff see a banner and decide whether to revise — so
+   * adding a workflow to a job with a signed SOW leaves that SOW exactly as
+   * signed.
+   */
+  async refreshDocumentStale(sowId: string): Promise<boolean> {
+    const sow = await this.sowModel.findById(sowId).exec();
+    if (!sow) return false;
+
+    const current = await this.getCurrentVersion(String(sowId));
+    if (!current) {
+      // No document yet: nothing can be out of date.
+      if (sow.documentStale) await this.sowModel.findByIdAndUpdate(sowId, { $set: { documentStale: false } }).exec();
+      return false;
+    }
+
+    const live = SowVersionService.deriveInputs(sow, { customerCategory: current.inputs?.customerCategory });
+    const stale = SowVersionService.billingFingerprint(live) !== SowVersionService.billingFingerprint(current.inputs ?? ({} as SowVersionInputs));
+
+    if (stale !== sow.documentStale) {
+      await this.sowModel.findByIdAndUpdate(sowId, { $set: { documentStale: stale } }).exec();
+    }
+    return stale;
+  }
+}

--- a/src/sow/sow-version.service.ts
+++ b/src/sow/sow-version.service.ts
@@ -82,7 +82,8 @@ export class SowVersionService {
         serviceId: String(s.serviceId ?? s._id ?? ''),
         name: s.name ?? 'Service',
         description: s.description ?? '',
-        cost: Number(s.cost ?? 0)
+        cost: Number(s.cost ?? 0),
+        runCount: s.runCount
       })),
       adjustments: (sow.pricing?.adjustments ?? [])
         .filter((a) => a.type !== SOWAdjustmentType.SPECIAL_TERM)
@@ -323,9 +324,19 @@ export class SowVersionService {
       deliverables: inputs.deliverables ?? stored.deliverables,
       // Unsaved billing edits still need to show in the preview, but only as
       // costs applied to lines the SOW already has — a preview cannot invent one.
-      services: (stored.services ?? []).map((s) => {
-        const edited = (inputs.services ?? []).find((x) => String(x.serviceId) === String(s.serviceId));
-        return edited && Number.isFinite(edited.cost) && edited.cost >= 0 ? { ...s, cost: edited.cost } : s;
+      // Matched by position, not serviceId: the same catalogue service can appear
+      // on more than one line (different run counts), and a serviceId lookup
+      // would apply the first matching line's edit to every line sharing that id
+      // — see the identical reasoning on SOWService.applyDocumentBilling. Unlike
+      // that save path, there's no length gate here: a preview must keep showing
+      // whatever edits it safely can rather than dropping all of them the moment
+      // the arrays are transiently out of step (e.g. mid-render while inputs are
+      // still loading) — a line whose position no longer matches its own
+      // serviceId just falls through to the stored value, same as a genuine
+      // mismatch would.
+      services: (stored.services ?? []).map((s, i) => {
+        const edited = inputs.services?.[i];
+        return edited && String(edited.serviceId) === String(s.serviceId) && Number.isFinite(edited.cost) && edited.cost >= 0 ? { ...s, cost: edited.cost } : s;
       }),
       adjustments: (inputs.adjustments ?? stored.adjustments ?? []).filter((a) => a.type !== SOWAdjustmentType.SPECIAL_TERM)
     };

--- a/src/sow/sow-version.service.ts
+++ b/src/sow/sow-version.service.ts
@@ -5,6 +5,7 @@ import mongoose from 'mongoose';
 import { SOW, SOWDocument, SOWStatus, SOWAdjustmentType } from './sow.model';
 import { SowVersion, SowVersionDocument, SowVersionInputs, SowField, SowFieldKind, SowPeriod, SowConsent } from './sow-version.model';
 import { buildCalculatedFields, calculateFieldValues, normalizeIncomingFields, SowDocumentContext } from './sow-field-calculator';
+import { SOW_FIELD_CATALOG } from './sow-field-defaults';
 import { SOWService } from './sow.service';
 import { SaveSowVersionInput } from './dto/save-sow-version.input';
 import { SignSowInput } from './dto/sign-sow.input';
@@ -117,6 +118,33 @@ export class SowVersionService {
   }
 
   /**
+   * versionNumber encodes its own "<sent-count>.<sub-revision>" display label —
+   * major*MINOR_WIDTH + minor — rather than that label being a second, separately
+   * computed value. One number for a version to have, not two that can drift
+   * apart or fall out of sync depending on which code path produced it.
+   *
+   * MINOR_WIDTH is headroom, not a hard limit read back out: nothing ever divides
+   * or reads a raw versionNumber except encode/decode, so there is no overflow
+   * to guard against, only an assumption (at most 999 saves between sends) that
+   * would need revisiting if ever seriously threatened.
+   */
+  private static readonly MINOR_WIDTH = 1000;
+
+  static encodeVersionNumber(major: number, minor: number): number {
+    return major * SowVersionService.MINOR_WIDTH + minor;
+  }
+
+  static decodeVersionNumber(versionNumber: number): { major: number; minor: number } {
+    return { major: Math.floor(versionNumber / SowVersionService.MINOR_WIDTH), minor: versionNumber % SowVersionService.MINOR_WIDTH };
+  }
+
+  /** Human-facing "<sent-count>.<sub-revision>" label, e.g. "1.2". */
+  static displayVersionLabel(versionNumber: number): string {
+    const { major, minor } = SowVersionService.decodeVersionNumber(versionNumber);
+    return `${major}.${minor}`;
+  }
+
+  /**
    * The newest version that still counts — what the editor opens and what the
    * transitions act on. Discarded drafts are skipped: after abandoning one, staff
    * must land back on real content rather than the draft they just threw away.
@@ -131,17 +159,29 @@ export class SowVersionService {
   /**
    * Next free version number, counting discarded drafts.
    *
-   * Numbers are never reused. Discarding v4 rolls the current pointer back to v3,
-   * but the next save must still be v5 — reusing 4 would collide with the
-   * discarded row on the unique {sowId, versionNumber} index, and would make the
-   * history read as though the abandoned draft had been edited into existence.
+   * A send bumps the whole number and resets the sub-revision; anything else — a
+   * plain save, a signature, a countersignature, a cancellation — just bumps the
+   * sub-revision. Numbers are never reused: discarding v1.3 rolls the current
+   * pointer back to v1.2, but the next save must still be v1.4 — reusing 1.3
+   * would collide with the discarded row on the unique {sowId, versionNumber}
+   * index, and would make the history read as though the abandoned draft had
+   * been edited into existence.
+   *
+   * The very first version of a SOW is the one exception to "minor starts at
+   * 0": it starts at 1 (so "0.1", not "0.0"). currentVersionNumber and
+   * activeVersionNumber use bare 0 to mean "no version yet" (see
+   * getActiveVersion), and encode(0, 0) is also 0 — reusing it for a real
+   * version would make the very first draft indistinguishable from "nothing
+   * exists yet" everywhere that sentinel is checked.
    */
-  private async nextVersionNumber(sowId: string): Promise<number> {
+  private async nextVersionNumber(sowId: string, opts: { bumpMajor: boolean }): Promise<number> {
     const highest = await this.versionModel
       .findOne({ sowId: String(sowId) })
       .sort({ versionNumber: -1 })
       .exec();
-    return (highest?.versionNumber ?? 0) + 1;
+    if (!highest) return SowVersionService.encodeVersionNumber(opts.bumpMajor ? 1 : 0, opts.bumpMajor ? 0 : 1);
+    const { major, minor } = SowVersionService.decodeVersionNumber(highest.versionNumber);
+    return opts.bumpMajor ? SowVersionService.encodeVersionNumber(major + 1, 0) : SowVersionService.encodeVersionNumber(major, minor + 1);
   }
 
   async getVersion(sowId: string, versionNumber: number): Promise<SowVersionDocument | null> {
@@ -175,11 +215,14 @@ export class SowVersionService {
     const fields = opts.fields ?? buildCalculatedFields(inputs, ctx);
     const status = opts.status ?? SOWStatus.DRAFT;
     const visibleToCustomer = opts.visibleToCustomer ?? status !== SOWStatus.DRAFT;
+    // A version created already issued (migration, or an opts.status override)
+    // counts as its own send — same rule sendToCustomer applies going forward.
+    const versionNumber = await this.nextVersionNumber(sowId, { bumpMajor: status !== SOWStatus.DRAFT });
 
     const created = await this.versionModel.create({
       sow: new mongoose.Types.ObjectId(sowId),
       sowId,
-      versionNumber: 1,
+      versionNumber,
       fields,
       inputs,
       status,
@@ -194,8 +237,8 @@ export class SowVersionService {
     await this.sowModel
       .findByIdAndUpdate(sowId, {
         $set: {
-          currentVersionNumber: 1,
-          activeVersionNumber: visibleToCustomer ? 1 : 0,
+          currentVersionNumber: versionNumber,
+          activeVersionNumber: visibleToCustomer ? versionNumber : 0,
           documentStale: false
         }
       })
@@ -227,7 +270,10 @@ export class SowVersionService {
     author: { sub: string; name: string }
   ): Promise<SowVersionDocument> {
     const sowId = String(sow._id);
-    const versionNumber = await this.nextVersionNumber(sowId);
+    // Sending is the only one of these four transitions that is itself "a
+    // send" — sign/finalize/cancel record an event against the version
+    // already in force, so they only bump the sub-revision.
+    const versionNumber = await this.nextVersionNumber(sowId, { bumpMajor: changes.status === SOWStatus.SENT });
 
     const created = await this.versionModel.create({
       sow: new mongoose.Types.ObjectId(sowId),
@@ -348,12 +394,15 @@ export class SowVersionService {
 
     const ctx = SowVersionService.buildContext(fresh, job);
     const fields = normalizeIncomingFields(
-      (input.fields ?? []).map((f) => ({ key: f.key, label: f.label ?? '', value: f.value ?? '', isEnabled: f.isEnabled !== false } as SowField)),
+      (input.fields ?? []).map((f) => ({ key: f.key, label: f.label ?? '', value: f.value ?? '', isEnabled: f.isEnabled !== false, requiresInitials: f.requiresInitials === true } as SowField)),
       inputs,
-      ctx
+      ctx,
+      current?.fields ?? []
     );
 
-    const versionNumber = await this.nextVersionNumber(sowId);
+    // A save is never itself a send, whatever status the version it's built on
+    // was in — that's what lets staff revise a sent/signed/finalized SOW.
+    const versionNumber = await this.nextVersionNumber(sowId, { bumpMajor: false });
     const created = await this.versionModel.create({
       sow: new mongoose.Types.ObjectId(sowId),
       sowId,
@@ -405,12 +454,32 @@ export class SowVersionService {
     return updated as SOW;
   }
 
+  /**
+   * Fields the document cannot be sent without: hidden or empty means the
+   * customer would see a blank or missing section (Engagement Resources with no
+   * Project Manager or Project Lead selected, for instance).
+   */
+  private static missingRequiredFields(fields: SowField[]): string[] {
+    const byKey = new Map(fields.map((f) => [f.key, f]));
+    return SOW_FIELD_CATALOG.filter((def) => !def.allowsEmpty)
+      .filter((def) => {
+        const field = byKey.get(def.key);
+        return !field || !field.isEnabled || !field.value?.trim();
+      })
+      .map((def) => def.label);
+  }
+
   /** Issues the current draft to the customer. */
   async sendToCustomer(sowId: string, author: { sub: string; name: string }): Promise<SowVersionDocument> {
     const sow = await this.requireSow(sowId);
     const current = await this.getCurrentVersion(sowId);
     if (!current) throw new BadRequestException('This SOW has no document to send.');
     if (current.status !== SOWStatus.DRAFT) throw new BadRequestException(`Only a draft can be sent; v${current.versionNumber} is ${current.status}.`);
+
+    const missing = SowVersionService.missingRequiredFields(current.fields ?? []);
+    if (missing.length > 0) {
+      throw new BadRequestException(`Complete the following before sending to the customer: ${missing.join(', ')}.`);
+    }
 
     const now = new Date();
     return this.appendVersion(sow, current, { status: SOWStatus.SENT, sentToCustomerAt: now, makeActive: true, note: 'Sent to customer' }, author);
@@ -444,10 +513,21 @@ export class SowVersionService {
       throw new BadRequestException(`Please confirm every section before signing. Missing: ${missing.join(', ')}.`);
     }
 
+    // Sections staff flagged requiresInitials each need their own typed initials,
+    // on top of the one overall consent checkbox.
+    const initialsByKey = new Map((input.sectionInitials ?? []).map((s) => [s.key, s.initials?.trim() ?? '']));
+    const enabledRequiringInitials = (active.fields ?? []).filter((f) => f.isEnabled && f.requiresInitials);
+    const missingInitials = enabledRequiringInitials.filter((f) => !initialsByKey.get(f.key));
+    if (missingInitials.length > 0) {
+      throw new BadRequestException(`Please initial the following before signing: ${missingInitials.map((f) => f.label).join(', ')}.`);
+    }
+    const sectionInitials = enabledRequiringInitials.map((f) => ({ key: f.key, label: f.label, initials: initialsByKey.get(f.key) ?? '' }));
+
     const signature: SowConsent = {
       name: input.name.trim(),
       signedAt: new Date(),
       consentedGroups: [...consented] as SowFieldKind[],
+      sectionInitials,
       bySub: user.sub
     };
 
@@ -466,6 +546,7 @@ export class SowVersionService {
       name: name.trim(),
       signedAt: new Date(),
       consentedGroups: [SowFieldKind.CALCULATED, SowFieldKind.PROSE, SowFieldKind.CUSTOM],
+      sectionInitials: [],
       bySub: author.sub
     };
 
@@ -479,24 +560,6 @@ export class SowVersionService {
     if (current.status === SOWStatus.CANCELLED) throw new BadRequestException('This SOW is already cancelled.');
 
     return this.appendVersion(sow, current, { status: SOWStatus.CANCELLED, makeActive: true, note: note ?? 'Cancelled' }, author);
-  }
-
-  /** Appends to the question thread. Staff and the job owner may both post. */
-  async addQuestion(sowId: string, text: string, author: { sub: string; name: string; isStaff: boolean }): Promise<SOW> {
-    if (!text?.trim()) throw new BadRequestException('A question cannot be empty.');
-    const sow = await this.requireSow(sowId);
-
-    const question = {
-      authorSub: author.sub,
-      authorName: author.name,
-      isStaff: author.isStaff,
-      text: text.trim(),
-      versionNumber: sow.activeVersionNumber || sow.currentVersionNumber || undefined,
-      createdAt: new Date()
-    };
-
-    const updated = await this.sowModel.findByIdAndUpdate(sowId, { $push: { questions: question } }, { new: true }).exec();
-    return updated as SOW;
   }
 
   /**

--- a/src/sow/sow-version.service.ts
+++ b/src/sow/sow-version.service.ts
@@ -375,6 +375,11 @@ export class SowVersionService {
       throw new ConflictException(`This SOW has moved on since you opened it (you have v${input.baseVersionNumber}, it is now v${currentNumber}). Reload to see the newer version before saving.`);
     }
 
+    // Non-nullable in the schema already stops an omitted note; this catches the
+    // whitespace-only one, which would satisfy the type and tell a reader nothing.
+    const note = input.note?.trim();
+    if (!note) throw new BadRequestException('Describe what you changed before saving.');
+
     // Billing figures first: the fee schedule text is generated from the billing
     // core, so it has to be written before the document is composed or the saved
     // text would describe the previous prices.
@@ -423,7 +428,7 @@ export class SowVersionService {
       status: SOWStatus.DRAFT,
       visibleToCustomer: false,
       isDiscarded: false,
-      note: input.note,
+      note,
       createdBy: author.sub,
       createdByName: author.name,
       createdAt: new Date()

--- a/src/sow/sow-version.transitions.spec.ts
+++ b/src/sow/sow-version.transitions.spec.ts
@@ -46,7 +46,17 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
         { key: 'billToAddress', label: 'Bill To Address', kind: SowFieldKind.PROSE, order: 110, value: 'x', isOverridden: false, isEnabled: true, allowsTextOverride: true },
         { key: 'feeSchedule', label: 'Fee Schedule', kind: SowFieldKind.CALCULATED, order: 100, value: 'Total: $0.00', isOverridden: false, isEnabled: true, allowsTextOverride: false },
         // Required before send — see sow-field-defaults.ts's allowsEmpty.
-        { key: 'engagementResources', label: 'Engagement Resources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isOverridden: false, isEnabled: true, allowsTextOverride: true, allowsEmpty: false }
+        {
+          key: 'engagementResources',
+          label: 'Engagement Resources',
+          kind: SowFieldKind.CALCULATED,
+          order: 50,
+          value: 'Jane Doe – Project Manager',
+          isOverridden: false,
+          isEnabled: true,
+          allowsTextOverride: true,
+          allowsEmpty: false
+        }
       ],
       inputs: { services: [], adjustments: [], baseCost: 0, totalCost: 0, periods: [], scopeOfWork: [], deliverables: [], projectManager: '', projectLead: '' },
       status: initial.status ?? SOWStatus.DRAFT,
@@ -135,7 +145,9 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
 const staff = { sub: 'sub-staff', name: 'tech' };
 const owner = { sub: 'sub-owner', email: 'client@lab.org', preferred_username: 'jane', realm_access: { roles: [] } } as User;
 
-const saveInput = (base: number, note?: string): any => ({
+// A note is required on every save, so the default stands in for one the test
+// does not care about; the tests that do care pass their own.
+const saveInput = (base: number, note = 'edited'): any => ({
   baseVersionNumber: base,
   note,
   // The real editor always resubmits its whole local field set, never a subset —
@@ -173,6 +185,21 @@ describe('saveVersion', () => {
     sow.documentStale = true;
     await service.saveVersion(SOW_ID, saveInput(1), staff);
     expect(sow.documentStale).toBe(false);
+  });
+
+  it('rejects a save whose note is only whitespace', async () => {
+    // The schema stops a missing note; this is the one that would otherwise slip
+    // through typed and still leave the history entry unlabelled.
+    const { service } = makeHarness();
+    await expect(service.saveVersion(SOW_ID, saveInput(1, '   '), staff)).rejects.toThrow(BadRequestException);
+  });
+
+  it('still lets the canned event versions through without an author note', async () => {
+    // sendToCustomer/sign/finalize write via appendVersion, not the save input,
+    // so requiring a note on saves must not reach them.
+    const { service } = makeHarness();
+    const sent = await service.sendToCustomer(SOW_ID, staff);
+    expect(sent.note).toBe('Sent to customer');
   });
 });
 
@@ -229,7 +256,17 @@ describe('sign', () => {
         { key: 'billToAddress', kind: SowFieldKind.PROSE, order: 110, value: 'x', isEnabled: true, allowsTextOverride: true, label: 'b', isOverridden: false },
         // Required, so it must stay enabled for sendToCustomer to succeed — it is
         // the CALCULATED section present, not custom-1, which stays disabled.
-        { key: 'engagementResources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isEnabled: true, allowsTextOverride: true, allowsEmpty: false, label: 'Engagement Resources', isOverridden: false },
+        {
+          key: 'engagementResources',
+          kind: SowFieldKind.CALCULATED,
+          order: 50,
+          value: 'Jane Doe – Project Manager',
+          isEnabled: true,
+          allowsTextOverride: true,
+          allowsEmpty: false,
+          label: 'Engagement Resources',
+          isOverridden: false
+        },
         { key: 'custom-1', kind: SowFieldKind.CUSTOM, order: 1000, value: 'hidden', isEnabled: false, allowsTextOverride: true, label: 'c', isOverridden: false }
       ]
     });
@@ -253,7 +290,17 @@ describe('sign', () => {
           isOverridden: false,
           requiresInitials: true
         },
-        { key: 'engagementResources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isEnabled: true, allowsTextOverride: true, allowsEmpty: false, label: 'Engagement Resources', isOverridden: false }
+        {
+          key: 'engagementResources',
+          kind: SowFieldKind.CALCULATED,
+          order: 50,
+          value: 'Jane Doe – Project Manager',
+          isEnabled: true,
+          allowsTextOverride: true,
+          allowsEmpty: false,
+          label: 'Engagement Resources',
+          isOverridden: false
+        }
       ]
     });
     await h.service.sendToCustomer(SOW_ID, staff);
@@ -284,7 +331,17 @@ describe('sign', () => {
           isOverridden: false,
           requiresInitials: true
         },
-        { key: 'engagementResources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isEnabled: true, allowsTextOverride: true, allowsEmpty: false, label: 'Engagement Resources', isOverridden: false }
+        {
+          key: 'engagementResources',
+          kind: SowFieldKind.CALCULATED,
+          order: 50,
+          value: 'Jane Doe – Project Manager',
+          isEnabled: true,
+          allowsTextOverride: true,
+          allowsEmpty: false,
+          label: 'Engagement Resources',
+          isOverridden: false
+        }
       ]
     });
     await h.service.sendToCustomer(SOW_ID, staff);

--- a/src/sow/sow-version.transitions.spec.ts
+++ b/src/sow/sow-version.transitions.spec.ts
@@ -44,7 +44,9 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
       versionNumber: 1,
       fields: initial.fields ?? [
         { key: 'billToAddress', label: 'Bill To Address', kind: SowFieldKind.PROSE, order: 110, value: 'x', isOverridden: false, isEnabled: true, allowsTextOverride: true },
-        { key: 'feeSchedule', label: 'Fee Schedule', kind: SowFieldKind.CALCULATED, order: 100, value: 'Total: $0.00', isOverridden: false, isEnabled: true, allowsTextOverride: false }
+        { key: 'feeSchedule', label: 'Fee Schedule', kind: SowFieldKind.CALCULATED, order: 100, value: 'Total: $0.00', isOverridden: false, isEnabled: true, allowsTextOverride: false },
+        // Required before send — see sow-field-defaults.ts's allowsEmpty.
+        { key: 'engagementResources', label: 'Engagement Resources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isOverridden: false, isEnabled: true, allowsTextOverride: true, allowsEmpty: false }
       ],
       inputs: { services: [], adjustments: [], baseCost: 0, totalCost: 0, periods: [], scopeOfWork: [], deliverables: [], projectManager: '', projectLead: '' },
       status: initial.status ?? SOWStatus.DRAFT,
@@ -68,8 +70,7 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
     timeline: { startDate: new Date('2026-03-03T00:00:00Z'), duration: '14 days' },
     resources: { projectManager: '', projectLead: '' },
     scopeOfWork: [],
-    deliverables: [],
-    questions: []
+    deliverables: []
   };
 
   const versionModel: any = {
@@ -118,7 +119,6 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
     findByIdAndUpdate: (_id: any, u: any): any => ({
       exec: async (): Promise<any> => {
         Object.assign(sow, u.$set ?? {});
-        if (u.$push?.questions) sow.questions.push(u.$push.questions);
         return sow;
       }
     })
@@ -138,7 +138,13 @@ const owner = { sub: 'sub-owner', email: 'client@lab.org', preferred_username: '
 const saveInput = (base: number, note?: string): any => ({
   baseVersionNumber: base,
   note,
-  fields: [{ key: 'billToAddress', value: 'edited', isEnabled: true }],
+  // The real editor always resubmits its whole local field set, never a subset —
+  // this mirrors that so a save doesn't drop Engagement Resources back to
+  // disabled the way an actually-partial request deliberately does.
+  fields: [
+    { key: 'billToAddress', value: 'edited', isEnabled: true },
+    { key: 'engagementResources', value: 'PM – Project Manager\nPL – Project Lead', isEnabled: true }
+  ],
   inputs: { projectManager: 'PM', projectLead: 'PL', periods: [], scopeOfWork: [], deliverables: [], services: [], adjustments: [] }
 });
 
@@ -221,11 +227,68 @@ describe('sign', () => {
     const h = makeHarness({
       fields: [
         { key: 'billToAddress', kind: SowFieldKind.PROSE, order: 110, value: 'x', isEnabled: true, allowsTextOverride: true, label: 'b', isOverridden: false },
+        // Required, so it must stay enabled for sendToCustomer to succeed — it is
+        // the CALCULATED section present, not custom-1, which stays disabled.
+        { key: 'engagementResources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isEnabled: true, allowsTextOverride: true, allowsEmpty: false, label: 'Engagement Resources', isOverridden: false },
         { key: 'custom-1', kind: SowFieldKind.CUSTOM, order: 1000, value: 'hidden', isEnabled: false, allowsTextOverride: true, label: 'c', isOverridden: false }
       ]
     });
     await h.service.sendToCustomer(SOW_ID, staff);
-    const v = await h.service.sign(SOW_ID, { versionNumber: h.sow.activeVersionNumber, name: 'Jane', consentedGroups: [SowFieldKind.PROSE] }, owner);
+    const v = await h.service.sign(SOW_ID, { versionNumber: h.sow.activeVersionNumber, name: 'Jane', consentedGroups: [SowFieldKind.PROSE, SowFieldKind.CALCULATED] }, owner);
+    expect(v.status).toBe(SOWStatus.SIGNED);
+  });
+
+  it('requires initials on a section staff flagged, and refuses to sign without them', async () => {
+    const h = makeHarness({
+      fields: [
+        { key: 'billToAddress', kind: SowFieldKind.PROSE, order: 110, value: 'x', isEnabled: true, allowsTextOverride: true, label: 'b', isOverridden: false },
+        {
+          key: 'clientResponsibilities',
+          kind: SowFieldKind.PROSE,
+          order: 90,
+          value: 'Ships samples on dry ice.',
+          isEnabled: true,
+          allowsTextOverride: true,
+          label: 'Client Responsibilities',
+          isOverridden: false,
+          requiresInitials: true
+        },
+        { key: 'engagementResources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isEnabled: true, allowsTextOverride: true, allowsEmpty: false, label: 'Engagement Resources', isOverridden: false }
+      ]
+    });
+    await h.service.sendToCustomer(SOW_ID, staff);
+
+    await expect(h.service.sign(SOW_ID, { versionNumber: h.sow.activeVersionNumber, name: 'Jane', consentedGroups: fullConsent }, owner)).rejects.toThrow(/initial/i);
+
+    const v = await h.service.sign(
+      SOW_ID,
+      { versionNumber: h.sow.activeVersionNumber, name: 'Jane', consentedGroups: fullConsent, sectionInitials: [{ key: 'clientResponsibilities', initials: 'JR' }] },
+      owner
+    );
+    expect(v.status).toBe(SOWStatus.SIGNED);
+    expect(v.clientSignature?.sectionInitials).toEqual([{ key: 'clientResponsibilities', label: 'Client Responsibilities', initials: 'JR' }]);
+  });
+
+  it('ignores a requiresInitials flag on a section the staff hid', async () => {
+    const h = makeHarness({
+      fields: [
+        { key: 'billToAddress', kind: SowFieldKind.PROSE, order: 110, value: 'x', isEnabled: true, allowsTextOverride: true, label: 'b', isOverridden: false },
+        {
+          key: 'clientResponsibilities',
+          kind: SowFieldKind.PROSE,
+          order: 90,
+          value: 'x',
+          isEnabled: false,
+          allowsTextOverride: true,
+          label: 'Client Responsibilities',
+          isOverridden: false,
+          requiresInitials: true
+        },
+        { key: 'engagementResources', kind: SowFieldKind.CALCULATED, order: 50, value: 'Jane Doe – Project Manager', isEnabled: true, allowsTextOverride: true, allowsEmpty: false, label: 'Engagement Resources', isOverridden: false }
+      ]
+    });
+    await h.service.sendToCustomer(SOW_ID, staff);
+    const v = await h.service.sign(SOW_ID, { versionNumber: h.sow.activeVersionNumber, name: 'Jane', consentedGroups: [SowFieldKind.PROSE, SowFieldKind.CALCULATED] }, owner);
     expect(v.status).toBe(SOWStatus.SIGNED);
   });
 
@@ -280,12 +343,12 @@ describe('finalize and the draft-above-final rule', () => {
 describe('discardDraft', () => {
   it('drops an unsent draft and rolls the staff pointer back', async () => {
     const { service, sow } = makeHarness();
-    await service.sendToCustomer(SOW_ID, staff); // v2 SENT, active=2
-    const draft = await service.saveVersion(SOW_ID, saveInput(2), staff); // v3 DRAFT
+    await service.sendToCustomer(SOW_ID, staff); // v1.0 (1000) SENT, active=1000
+    const draft = await service.saveVersion(SOW_ID, saveInput(1000), staff); // v1.1 (1001) DRAFT
 
     await service.discardDraft(SOW_ID, draft.versionNumber);
-    expect(sow.currentVersionNumber).toBe(2);
-    expect(sow.activeVersionNumber).toBe(2);
+    expect(sow.currentVersionNumber).toBe(1000);
+    expect(sow.activeVersionNumber).toBe(1000);
   });
 
   it('refuses to discard a version the customer has seen', async () => {
@@ -296,45 +359,32 @@ describe('discardDraft', () => {
 
   it('refuses to discard the only version, which would leave the SOW with no document', async () => {
     const { service } = makeHarness();
+    // The harness seeds v0.1 (encoded 1) — the very first version of any SOW,
+    // whose minor starts at 1 rather than 0 so it never collides with the
+    // "nothing sent yet" sentinel activeVersionNumber/currentVersionNumber use.
     await expect(service.discardDraft(SOW_ID, 1)).rejects.toThrow(/only version/i);
   });
 
   it('does not reopen the editor on the draft that was just discarded', async () => {
     const { service } = makeHarness();
-    await service.sendToCustomer(SOW_ID, staff); // v2 SENT
-    const draft = await service.saveVersion(SOW_ID, saveInput(2), staff); // v3 DRAFT
+    await service.sendToCustomer(SOW_ID, staff); // v1.0 (1000) SENT
+    const draft = await service.saveVersion(SOW_ID, saveInput(1000), staff); // v1.1 (1001) DRAFT
     await service.discardDraft(SOW_ID, draft.versionNumber);
 
     const current = await service.getCurrentVersion(SOW_ID);
-    expect(current?.versionNumber).toBe(2);
+    expect(current?.versionNumber).toBe(1000);
     expect(current?.status).toBe(SOWStatus.SENT);
   });
 
   it('does not reuse the discarded number, which would collide on the unique index', async () => {
     const { service } = makeHarness();
-    await service.sendToCustomer(SOW_ID, staff); // v2
-    const draft = await service.saveVersion(SOW_ID, saveInput(2), staff); // v3
+    await service.sendToCustomer(SOW_ID, staff); // v1.0 (1000)
+    const draft = await service.saveVersion(SOW_ID, saveInput(1000), staff); // v1.1 (1001)
     await service.discardDraft(SOW_ID, draft.versionNumber);
 
-    const next = await service.saveVersion(SOW_ID, saveInput(2), staff);
-    expect(next.versionNumber).toBe(4);
-  });
-});
-
-describe('questions', () => {
-  it('appends to the thread tagged with the version in force', async () => {
-    const { service, sow } = makeHarness();
-    await service.sendToCustomer(SOW_ID, staff);
-    await service.addQuestion(SOW_ID, '  Does the price include the QC rerun?  ', { sub: 'sub-owner', name: 'Jane', isStaff: false });
-
-    expect(sow.questions).toHaveLength(1);
-    expect(sow.questions[0].text).toBe('Does the price include the QC rerun?');
-    expect(sow.questions[0].isStaff).toBe(false);
-    expect(sow.questions[0].versionNumber).toBe(sow.activeVersionNumber);
-  });
-
-  it('rejects an empty question', async () => {
-    const { service } = makeHarness();
-    await expect(service.addQuestion(SOW_ID, '   ', { sub: 'x', name: 'x', isStaff: true })).rejects.toThrow(BadRequestException);
+    const next = await service.saveVersion(SOW_ID, saveInput(1000), staff);
+    // 1001 is still on the books (discarded, not deleted), so the next draft
+    // must skip past it to 1.2 (1002) rather than reusing 1.1.
+    expect(next.versionNumber).toBe(1002);
   });
 });

--- a/src/sow/sow-version.transitions.spec.ts
+++ b/src/sow/sow-version.transitions.spec.ts
@@ -1,0 +1,340 @@
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import mongoose from 'mongoose';
+import { SowVersionService } from './sow-version.service';
+import { SowFieldKind } from './sow-version.model';
+import { SOWStatus } from './sow.model';
+import { User } from '../auth/user.interface';
+
+/**
+ * Exercises the version state machine against in-memory stand-ins for the two
+ * mongoose models. The rule that matters most here is that saving never moves
+ * activeVersionNumber: that is what lets staff iterate on a signed SOW without
+ * invalidating the signature, and it is invisible to a type checker.
+ */
+
+const SOW_ID = new mongoose.Types.ObjectId().toHexString();
+
+interface FakeVersion {
+  _id: string;
+  sowId: string;
+  versionNumber: number;
+  fields: any[];
+  inputs: any;
+  status: SOWStatus;
+  visibleToCustomer: boolean;
+  isDiscarded: boolean;
+  clientSignature?: any;
+  staffSignature?: any;
+  sentToCustomerAt?: Date;
+  note?: string;
+  createdBy: string;
+  createdByName: string;
+  createdAt: Date;
+}
+
+function matches(doc: any, query: Record<string, any>): boolean {
+  return Object.entries(query).every(([k, v]) => String(doc[k]) === String(v));
+}
+
+function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { service: SowVersionService; sow: any; versions: FakeVersion[] } {
+  const versions: FakeVersion[] = [
+    {
+      _id: 'v1',
+      sowId: SOW_ID,
+      versionNumber: 1,
+      fields: initial.fields ?? [
+        { key: 'billToAddress', label: 'Bill To Address', kind: SowFieldKind.PROSE, order: 110, value: 'x', isOverridden: false, isEnabled: true, allowsTextOverride: true },
+        { key: 'feeSchedule', label: 'Fee Schedule', kind: SowFieldKind.CALCULATED, order: 100, value: 'Total: $0.00', isOverridden: false, isEnabled: true, allowsTextOverride: false }
+      ],
+      inputs: { services: [], adjustments: [], baseCost: 0, totalCost: 0, periods: [], scopeOfWork: [], deliverables: [], projectManager: '', projectLead: '' },
+      status: initial.status ?? SOWStatus.DRAFT,
+      visibleToCustomer: false,
+      isDiscarded: false,
+      createdBy: 'tech',
+      createdByName: 'tech',
+      createdAt: new Date()
+    }
+  ];
+
+  const sow: any = {
+    _id: SOW_ID,
+    jobId: 'job-1',
+    sowNumber: 'SOW 001',
+    currentVersionNumber: 1,
+    activeVersionNumber: 0,
+    documentStale: false,
+    services: [],
+    pricing: { baseCost: 0, adjustments: [], totalCost: 0 },
+    timeline: { startDate: new Date('2026-03-03T00:00:00Z'), duration: '14 days' },
+    resources: { projectManager: '', projectLead: '' },
+    scopeOfWork: [],
+    deliverables: [],
+    questions: []
+  };
+
+  const versionModel: any = {
+    findOne: (q: any): any => {
+      const found = versions.filter((v) => matches(v, q));
+      const api = {
+        sort: (spec: any): any => {
+          const key = Object.keys(spec)[0];
+          const dir = spec[key];
+          const sorted = [...found].sort((a: any, b: any) => (a[key] - b[key]) * dir);
+          return { exec: async () => sorted[0] ?? null };
+        },
+        exec: async () => found[0] ?? null
+      };
+      return api;
+    },
+    find: (q: any): any => ({
+      sort: (spec: any): any => {
+        const key = Object.keys(spec)[0];
+        const dir = spec[key];
+        return { exec: async () => versions.filter((v) => matches(v, q)).sort((a: any, b: any) => (a[key] - b[key]) * dir) };
+      }
+    }),
+    countDocuments: (q: any): any => ({
+      exec: async (): Promise<number> => {
+        const { versionNumber, ...rest } = q ?? {};
+        const ne = versionNumber?.$ne;
+        return versions.filter((v) => matches(v, rest) && (ne === undefined || v.versionNumber !== ne)).length;
+      }
+    }),
+    create: async (doc: any): Promise<any> => {
+      const created = { ...doc, _id: `v${doc.versionNumber}`, sowId: String(doc.sowId) };
+      versions.push(created);
+      return created;
+    },
+    updateOne: (q: any, u: any): any => ({
+      exec: async (): Promise<void> => {
+        const target = versions.find((v) => matches(v, q));
+        if (target) Object.assign(target, u.$set ?? {});
+      }
+    })
+  };
+
+  const sowModel: any = {
+    findById: (): any => ({ exec: async (): Promise<any> => sow }),
+    findByIdAndUpdate: (_id: any, u: any): any => ({
+      exec: async (): Promise<any> => {
+        Object.assign(sow, u.$set ?? {});
+        if (u.$push?.questions) sow.questions.push(u.$push.questions);
+        return sow;
+      }
+    })
+  };
+
+  const sowService: any = {
+    applyDocumentBilling: async () => sow,
+    getJobForSow: async () => ({ customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC', jobId: '04217', sub: 'sub-owner', email: 'client@lab.org' })
+  };
+
+  return { service: new SowVersionService(versionModel, sowModel, sowService), sow, versions };
+}
+
+const staff = { sub: 'sub-staff', name: 'tech' };
+const owner = { sub: 'sub-owner', email: 'client@lab.org', preferred_username: 'jane', realm_access: { roles: [] } } as User;
+
+const saveInput = (base: number, note?: string): any => ({
+  baseVersionNumber: base,
+  note,
+  fields: [{ key: 'billToAddress', value: 'edited', isEnabled: true }],
+  inputs: { projectManager: 'PM', projectLead: 'PL', periods: [], scopeOfWork: [], deliverables: [], services: [], adjustments: [] }
+});
+
+const fullConsent = [SowFieldKind.CALCULATED, SowFieldKind.PROSE, SowFieldKind.CUSTOM];
+
+describe('saveVersion', () => {
+  it('appends a draft and advances the staff pointer only', async () => {
+    const { service, sow } = makeHarness();
+    const v = await service.saveVersion(SOW_ID, saveInput(1, 'first pass'), staff);
+
+    expect(v.versionNumber).toBe(2);
+    expect(v.status).toBe(SOWStatus.DRAFT);
+    expect(v.visibleToCustomer).toBe(false);
+    expect(sow.currentVersionNumber).toBe(2);
+    expect(sow.activeVersionNumber).toBe(0);
+  });
+
+  it('rejects a save built on a version someone else has superseded', async () => {
+    const { service } = makeHarness();
+    await service.saveVersion(SOW_ID, saveInput(1), staff);
+    await expect(service.saveVersion(SOW_ID, saveInput(1), { sub: 'other', name: 'other' })).rejects.toThrow(ConflictException);
+  });
+
+  it('clears the stale flag, since the saved document now matches the billing core', async () => {
+    const { service, sow } = makeHarness();
+    sow.documentStale = true;
+    await service.saveVersion(SOW_ID, saveInput(1), staff);
+    expect(sow.documentStale).toBe(false);
+  });
+});
+
+describe('sendToCustomer', () => {
+  it('issues the draft and moves the customer pointer', async () => {
+    const { service, sow } = makeHarness();
+    const v = await service.sendToCustomer(SOW_ID, staff);
+
+    expect(v.status).toBe(SOWStatus.SENT);
+    expect(v.visibleToCustomer).toBe(true);
+    expect(v.sentToCustomerAt).toBeInstanceOf(Date);
+    expect(sow.activeVersionNumber).toBe(v.versionNumber);
+  });
+
+  it('refuses to send anything but a draft', async () => {
+    const { service } = makeHarness();
+    await service.sendToCustomer(SOW_ID, staff);
+    await expect(service.sendToCustomer(SOW_ID, staff)).rejects.toThrow(BadRequestException);
+  });
+});
+
+describe('sign', () => {
+  async function sent(): Promise<ReturnType<typeof makeHarness>> {
+    const h = makeHarness();
+    await h.service.sendToCustomer(SOW_ID, staff);
+    return h;
+  }
+
+  it('records the signature and moves the pointer', async () => {
+    const { service, sow } = await sent();
+    const active = sow.activeVersionNumber;
+    const v = await service.sign(SOW_ID, { versionNumber: active, name: 'Jane Rivera', consentedGroups: fullConsent }, owner);
+
+    expect(v.status).toBe(SOWStatus.SIGNED);
+    expect(v.clientSignature?.name).toBe('Jane Rivera');
+    expect(v.clientSignature?.bySub).toBe('sub-owner');
+    expect(sow.activeVersionNumber).toBe(v.versionNumber);
+  });
+
+  it('refuses a signature aimed at a superseded version', async () => {
+    const { service, sow } = await sent();
+    await expect(service.sign(SOW_ID, { versionNumber: sow.activeVersionNumber - 1, name: 'Jane', consentedGroups: fullConsent }, owner)).rejects.toThrow(ConflictException);
+  });
+
+  it('requires every group present in the document to be acknowledged', async () => {
+    const { service, sow } = await sent();
+    // The document has PROSE and CALCULATED sections; consenting to one is not enough.
+    await expect(service.sign(SOW_ID, { versionNumber: sow.activeVersionNumber, name: 'Jane', consentedGroups: [SowFieldKind.PROSE] }, owner)).rejects.toThrow(/Missing/);
+  });
+
+  it('ignores groups that only appear in disabled sections', async () => {
+    const h = makeHarness({
+      fields: [
+        { key: 'billToAddress', kind: SowFieldKind.PROSE, order: 110, value: 'x', isEnabled: true, allowsTextOverride: true, label: 'b', isOverridden: false },
+        { key: 'custom-1', kind: SowFieldKind.CUSTOM, order: 1000, value: 'hidden', isEnabled: false, allowsTextOverride: true, label: 'c', isOverridden: false }
+      ]
+    });
+    await h.service.sendToCustomer(SOW_ID, staff);
+    const v = await h.service.sign(SOW_ID, { versionNumber: h.sow.activeVersionNumber, name: 'Jane', consentedGroups: [SowFieldKind.PROSE] }, owner);
+    expect(v.status).toBe(SOWStatus.SIGNED);
+  });
+
+  it('requires a typed name', async () => {
+    const { service, sow } = await sent();
+    await expect(service.sign(SOW_ID, { versionNumber: sow.activeVersionNumber, name: '   ', consentedGroups: fullConsent }, owner)).rejects.toThrow(BadRequestException);
+  });
+
+  it('cannot sign a draft that was never sent', async () => {
+    const { service } = makeHarness();
+    await expect(service.sign(SOW_ID, { versionNumber: 1, name: 'Jane', consentedGroups: fullConsent }, owner)).rejects.toThrow(BadRequestException);
+  });
+});
+
+describe('finalize and the draft-above-final rule', () => {
+  async function finalized(): Promise<ReturnType<typeof makeHarness>> {
+    const h = makeHarness();
+    await h.service.sendToCustomer(SOW_ID, staff);
+    await h.service.sign(SOW_ID, { versionNumber: h.sow.activeVersionNumber, name: 'Jane Rivera', consentedGroups: fullConsent }, owner);
+    await h.service.finalize(SOW_ID, 'Courtney Tretheway', staff);
+    return h;
+  }
+
+  it('countersigns a signed SOW', async () => {
+    const { sow, versions } = await finalized();
+    const final = versions.find((v) => v.versionNumber === sow.activeVersionNumber);
+    expect(final?.status).toBe(SOWStatus.FINAL);
+    expect(final?.staffSignature?.name).toBe('Courtney Tretheway');
+    // the customer signature carries forward onto the final record
+    expect(final?.clientSignature?.name).toBe('Jane Rivera');
+  });
+
+  it('refuses to finalize anything but a signed SOW', async () => {
+    const { service } = makeHarness();
+    await expect(service.finalize(SOW_ID, 'Someone', staff)).rejects.toThrow(BadRequestException);
+  });
+
+  it('leaves the finalized version in force when staff start a new draft', async () => {
+    const { service, sow } = await finalized();
+    const finalNumber = sow.activeVersionNumber;
+
+    const draft = await service.saveVersion(SOW_ID, saveInput(sow.currentVersionNumber, 'proposed revision'), staff);
+
+    expect(draft.status).toBe(SOWStatus.DRAFT);
+    expect(sow.currentVersionNumber).toBe(draft.versionNumber);
+    // The whole point of the two-pointer split: the customer is still bound by
+    // the finalized version until someone deliberately sends the revision.
+    expect(sow.activeVersionNumber).toBe(finalNumber);
+  });
+});
+
+describe('discardDraft', () => {
+  it('drops an unsent draft and rolls the staff pointer back', async () => {
+    const { service, sow } = makeHarness();
+    await service.sendToCustomer(SOW_ID, staff); // v2 SENT, active=2
+    const draft = await service.saveVersion(SOW_ID, saveInput(2), staff); // v3 DRAFT
+
+    await service.discardDraft(SOW_ID, draft.versionNumber);
+    expect(sow.currentVersionNumber).toBe(2);
+    expect(sow.activeVersionNumber).toBe(2);
+  });
+
+  it('refuses to discard a version the customer has seen', async () => {
+    const { service, sow } = makeHarness();
+    await service.sendToCustomer(SOW_ID, staff);
+    await expect(service.discardDraft(SOW_ID, sow.activeVersionNumber)).rejects.toThrow(BadRequestException);
+  });
+
+  it('refuses to discard the only version, which would leave the SOW with no document', async () => {
+    const { service } = makeHarness();
+    await expect(service.discardDraft(SOW_ID, 1)).rejects.toThrow(/only version/i);
+  });
+
+  it('does not reopen the editor on the draft that was just discarded', async () => {
+    const { service } = makeHarness();
+    await service.sendToCustomer(SOW_ID, staff); // v2 SENT
+    const draft = await service.saveVersion(SOW_ID, saveInput(2), staff); // v3 DRAFT
+    await service.discardDraft(SOW_ID, draft.versionNumber);
+
+    const current = await service.getCurrentVersion(SOW_ID);
+    expect(current?.versionNumber).toBe(2);
+    expect(current?.status).toBe(SOWStatus.SENT);
+  });
+
+  it('does not reuse the discarded number, which would collide on the unique index', async () => {
+    const { service } = makeHarness();
+    await service.sendToCustomer(SOW_ID, staff); // v2
+    const draft = await service.saveVersion(SOW_ID, saveInput(2), staff); // v3
+    await service.discardDraft(SOW_ID, draft.versionNumber);
+
+    const next = await service.saveVersion(SOW_ID, saveInput(2), staff);
+    expect(next.versionNumber).toBe(4);
+  });
+});
+
+describe('questions', () => {
+  it('appends to the thread tagged with the version in force', async () => {
+    const { service, sow } = makeHarness();
+    await service.sendToCustomer(SOW_ID, staff);
+    await service.addQuestion(SOW_ID, '  Does the price include the QC rerun?  ', { sub: 'sub-owner', name: 'Jane', isStaff: false });
+
+    expect(sow.questions).toHaveLength(1);
+    expect(sow.questions[0].text).toBe('Does the price include the QC rerun?');
+    expect(sow.questions[0].isStaff).toBe(false);
+    expect(sow.questions[0].versionNumber).toBe(sow.activeVersionNumber);
+  });
+
+  it('rejects an empty question', async () => {
+    const { service } = makeHarness();
+    await expect(service.addQuestion(SOW_ID, '   ', { sub: 'x', name: 'x', isStaff: true })).rejects.toThrow(BadRequestException);
+  });
+});

--- a/src/sow/sow-version.transitions.spec.ts
+++ b/src/sow/sow-version.transitions.spec.ts
@@ -388,3 +388,28 @@ describe('discardDraft', () => {
     expect(next.versionNumber).toBe(1002);
   });
 });
+
+describe('previewCalculatedValues', () => {
+  it('keeps each line at its own edited cost when the same service appears twice', async () => {
+    const { service, sow } = makeHarness();
+    sow.services = [
+      { serviceId: 'pcr', name: 'PCR', description: '', cost: 350 }, // 70 runs
+      { serviceId: 'pcr', name: 'PCR', description: '', cost: 5 } // 1 run
+    ];
+
+    const preview = await service.previewCalculatedValues(SOW_ID, {
+      services: [
+        { serviceId: 'pcr', name: 'PCR', description: '', cost: 350 },
+        { serviceId: 'pcr', name: 'PCR', description: '', cost: 5 }
+      ]
+    } as any);
+
+    const feeSchedule = preview.find((f) => f.key === 'feeSchedule')?.calculatedValue ?? '';
+    // Both lines' costs must survive distinctly; a serviceId-keyed lookup would
+    // have applied the first line's edit ($350) to both, showing $700 total
+    // instead of $355 and losing the second line's true cost entirely.
+    expect(feeSchedule).toContain('$350.00');
+    expect(feeSchedule).toContain('$5.00');
+    expect(feeSchedule).toContain('Total: $355.00');
+  });
+});

--- a/src/sow/sow.model.ts
+++ b/src/sow/sow.model.ts
@@ -157,6 +157,10 @@ export class SOWService {
   @Prop({ required: true })
   @Field({ description: 'Category of the service' })
   category: string;
+
+  @Prop({ required: false })
+  @Field(() => Float, { nullable: true, description: 'The run-count multiplier baked into cost, if the underlying node has one. Informational — cost is the figure invoices read.' })
+  runCount?: number;
 }
 
 @Schema()

--- a/src/sow/sow.model.ts
+++ b/src/sow/sow.model.ts
@@ -1,7 +1,7 @@
 import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 import mongoose from 'mongoose';
-import { Field, ObjectType, ID, registerEnumType, Float } from '@nestjs/graphql';
+import { Field, ObjectType, ID, registerEnumType, Float, Int } from '@nestjs/graphql';
 import JSON from 'graphql-type-json';
 import { Job } from '../job/job.model';
 
@@ -159,6 +159,34 @@ export class SOWService {
   category: string;
 }
 
+@Schema({ _id: false })
+@ObjectType({ description: 'A question a customer asked about a SOW, or a staff reply' })
+export class SowQuestion {
+  @Prop({ required: true })
+  @Field({ description: 'Keycloak sub of the author' })
+  authorSub: string;
+
+  @Prop({ required: true, default: '' })
+  @Field({ defaultValue: '' })
+  authorName: string;
+
+  @Prop({ required: true, default: false })
+  @Field({ description: 'True when written by DampLab staff rather than the customer' })
+  isStaff: boolean;
+
+  @Prop({ required: true })
+  @Field()
+  text: string;
+
+  @Prop({ required: false })
+  @Field(() => Int, { nullable: true, description: 'Version the question was asked against' })
+  versionNumber?: number;
+
+  @Prop({ required: true, default: () => new Date() })
+  @Field()
+  createdAt: Date;
+}
+
 @Schema()
 @ObjectType({ description: 'Statement of Work (SOW) for a job' })
 export class SOW {
@@ -234,9 +262,14 @@ export class SOW {
   @Field(() => SOWPricing, { description: 'Pricing information' })
   pricing: SOWPricing;
 
-  @Prop({ required: true })
-  @Field({ description: 'Terms and conditions' })
-  terms: string;
+  /**
+   * Legacy. The document's terms now live in its versions' fields, where staff can
+   * edit them; nothing reads this any more. Kept, and kept optional, so existing
+   * rows keep their stored copy while newly generated SOWs simply have none.
+   */
+  @Prop({ required: false })
+  @Field({ description: 'Terms and conditions. Legacy — the live document text lives on the SOW version.', nullable: true })
+  terms?: string;
 
   @Prop({ required: false })
   @Field({ description: 'Additional information', nullable: true })
@@ -266,6 +299,33 @@ export class SOW {
   @Prop({ type: mongoose.Schema.Types.Mixed, required: false })
   @Field(() => SOWSignature, { description: 'Technician/BU signature (when present)', nullable: true })
   technicianSignature?: SOWSignature;
+
+  // ---------------------------------------------------------------------------
+  // Versioned document. The fields above remain the billing core (services,
+  // pricing) plus the legacy record that predates versioning; the document
+  // itself lives in the sow_versions collection.
+  // ---------------------------------------------------------------------------
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Int, { description: 'Highest version number; what staff edit. 0 before the first version exists.' })
+  currentVersionNumber: number;
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Int, {
+    description: 'Version in force with the customer. Lags currentVersionNumber while staff draft changes, which is why an unsent draft never invalidates a signature. 0 before anything is issued.'
+  })
+  activeVersionNumber: number;
+
+  @Prop({ required: true, default: false })
+  @Field({
+    description:
+      'The billing core moved (workflow added, category changed) since the current version was written, so its Fee Schedule is out of date. Surfaced to staff as a banner; never auto-applied to an issued document.'
+  })
+  documentStale: boolean;
+
+  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  @Field(() => [SowQuestion], { description: 'Append-only question thread between the customer and staff' })
+  questions: SowQuestion[];
 }
 
 export type SOWDocument = SOW & Document;

--- a/src/sow/sow.model.ts
+++ b/src/sow/sow.model.ts
@@ -2,7 +2,6 @@ import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 import mongoose from 'mongoose';
 import { Field, ObjectType, ID, registerEnumType, Float, Int } from '@nestjs/graphql';
-import JSON from 'graphql-type-json';
 import { Job } from '../job/job.model';
 
 export enum SOWStatus {

--- a/src/sow/sow.model.ts
+++ b/src/sow/sow.model.ts
@@ -159,34 +159,6 @@ export class SOWService {
   category: string;
 }
 
-@Schema({ _id: false })
-@ObjectType({ description: 'A question a customer asked about a SOW, or a staff reply' })
-export class SowQuestion {
-  @Prop({ required: true })
-  @Field({ description: 'Keycloak sub of the author' })
-  authorSub: string;
-
-  @Prop({ required: true, default: '' })
-  @Field({ defaultValue: '' })
-  authorName: string;
-
-  @Prop({ required: true, default: false })
-  @Field({ description: 'True when written by DampLab staff rather than the customer' })
-  isStaff: boolean;
-
-  @Prop({ required: true })
-  @Field()
-  text: string;
-
-  @Prop({ required: false })
-  @Field(() => Int, { nullable: true, description: 'Version the question was asked against' })
-  versionNumber?: number;
-
-  @Prop({ required: true, default: () => new Date() })
-  @Field()
-  createdAt: Date;
-}
-
 @Schema()
 @ObjectType({ description: 'Statement of Work (SOW) for a job' })
 export class SOW {
@@ -322,10 +294,6 @@ export class SOW {
       'The billing core moved (workflow added, category changed) since the current version was written, so its Fee Schedule is out of date. Surfaced to staff as a banner; never auto-applied to an issued document.'
   })
   documentStale: boolean;
-
-  @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
-  @Field(() => [SowQuestion], { description: 'Append-only question thread between the customer and staff' })
-  questions: SowQuestion[];
 }
 
 export type SOWDocument = SOW & Document;

--- a/src/sow/sow.module.ts
+++ b/src/sow/sow.module.ts
@@ -5,6 +5,7 @@ import { SowVersion, SowVersionSchema } from './sow-version.model';
 import { SOWService } from './sow.service';
 import { SowVersionService } from './sow-version.service';
 import { SOWResolver } from './sow.resolver';
+import { SowVersionFieldsResolver } from './sow-version-fields.resolver';
 import { JobModule } from '../job/job.module';
 import { DampLabServicesModule } from '../services/damplab-services.module';
 
@@ -17,7 +18,7 @@ import { DampLabServicesModule } from '../services/damplab-services.module';
     forwardRef(() => JobModule),
     DampLabServicesModule
   ],
-  providers: [SOWService, SowVersionService, SOWResolver],
+  providers: [SOWService, SowVersionService, SOWResolver, SowVersionFieldsResolver],
   exports: [SOWService, SowVersionService]
 })
 export class SOWModule {}

--- a/src/sow/sow.module.ts
+++ b/src/sow/sow.module.ts
@@ -1,14 +1,23 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { SOW, SOWSchema } from './sow.model';
+import { SowVersion, SowVersionSchema } from './sow-version.model';
 import { SOWService } from './sow.service';
+import { SowVersionService } from './sow-version.service';
 import { SOWResolver } from './sow.resolver';
 import { JobModule } from '../job/job.module';
 import { DampLabServicesModule } from '../services/damplab-services.module';
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: SOW.name, schema: SOWSchema }]), forwardRef(() => JobModule), DampLabServicesModule],
-  providers: [SOWService, SOWResolver],
-  exports: [SOWService]
+  imports: [
+    MongooseModule.forFeature([
+      { name: SOW.name, schema: SOWSchema },
+      { name: SowVersion.name, schema: SowVersionSchema }
+    ]),
+    forwardRef(() => JobModule),
+    DampLabServicesModule
+  ],
+  providers: [SOWService, SowVersionService, SOWResolver],
+  exports: [SOWService, SowVersionService]
 })
 export class SOWModule {}

--- a/src/sow/sow.resolver.spec.ts
+++ b/src/sow/sow.resolver.spec.ts
@@ -1,0 +1,91 @@
+import { ForbiddenException } from '@nestjs/common';
+import { SOWResolver } from './sow.resolver';
+import { Role } from '../auth/roles/roles.enum';
+import { User } from '../auth/user.interface';
+
+/**
+ * Exercises the resolver method bodies, not just the access predicate: the
+ * predicate is only correct if sowById/sowByJobId actually look up the right job
+ * and hand it over. A regression here would silently hide every customer's SOW.
+ */
+function user(overrides: Partial<User> = {}): User {
+  return { preferred_username: 'u', sub: 'sub-x', email: 'x@example.com', realm_access: { roles: [] }, ...overrides } as User;
+}
+
+const staff = user({ sub: 'sub-staff', email: 'tech@bu.edu', realm_access: { roles: [Role.DamplabStaff] } });
+const owner = user({ sub: 'sub-owner', email: 'client@lab.org' });
+const stranger = user({ sub: 'sub-other', email: 'other@example.com' });
+
+const SOW_ID = 'sow-1';
+const JOB_ID = 'job-1';
+const sow = { id: SOW_ID, jobId: JOB_ID, clientEmail: 'client@lab.org' } as any;
+const job = { sub: 'sub-owner', email: 'client@lab.org' } as any;
+
+function build(overrides: { sow?: any; job?: any } = {}): { resolver: SOWResolver; sowService: any; jobService: any } {
+  const sowService = {
+    findById: jest.fn().mockResolvedValue('sow' in overrides ? overrides.sow : sow),
+    findByJobId: jest.fn().mockResolvedValue('sow' in overrides ? overrides.sow : sow)
+  } as any;
+  const jobService = {
+    findById: jest.fn().mockResolvedValue('job' in overrides ? overrides.job : job)
+  } as any;
+  // Not exercised by these tests, which cover read access only.
+  const sowVersionService = {} as any;
+  return { resolver: new SOWResolver(sowService, jobService, sowVersionService), sowService, jobService };
+}
+
+describe('SOWResolver.sowByJobId', () => {
+  it('returns the SOW for staff', async () => {
+    const { resolver } = build();
+    await expect(resolver.sowByJobId(JOB_ID, staff)).resolves.toBe(sow);
+  });
+
+  it('returns the SOW for the job owner', async () => {
+    const { resolver } = build();
+    await expect(resolver.sowByJobId(JOB_ID, owner)).resolves.toBe(sow);
+  });
+
+  it('rejects an unrelated authenticated user', async () => {
+    const { resolver } = build();
+    await expect(resolver.sowByJobId(JOB_ID, stranger)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('looks up the job by the id it was asked about', async () => {
+    const { resolver, jobService } = build();
+    await resolver.sowByJobId(JOB_ID, staff);
+    expect(jobService.findById).toHaveBeenCalledWith(JOB_ID);
+  });
+
+  it('returns null without an access error when no SOW exists', async () => {
+    const { resolver } = build({ sow: null });
+    await expect(resolver.sowByJobId(JOB_ID, stranger)).resolves.toBeNull();
+  });
+});
+
+describe('SOWResolver.sowById', () => {
+  it('returns the SOW for staff', async () => {
+    const { resolver } = build();
+    await expect(resolver.sowById(SOW_ID, staff)).resolves.toBe(sow);
+  });
+
+  it('returns the SOW for the job owner', async () => {
+    const { resolver } = build();
+    await expect(resolver.sowById(SOW_ID, owner)).resolves.toBe(sow);
+  });
+
+  it('rejects an unrelated authenticated user', async () => {
+    const { resolver } = build();
+    await expect(resolver.sowById(SOW_ID, stranger)).rejects.toThrow(ForbiddenException);
+  });
+
+  it("resolves the job via the SOW's jobId, not the SOW id", async () => {
+    const { resolver, jobService } = build();
+    await resolver.sowById(SOW_ID, staff);
+    expect(jobService.findById).toHaveBeenCalledWith(JOB_ID);
+  });
+
+  it('does not leak a SOW whose job has gone missing', async () => {
+    const { resolver } = build({ job: null });
+    await expect(resolver.sowById(SOW_ID, owner)).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/src/sow/sow.resolver.ts
+++ b/src/sow/sow.resolver.ts
@@ -2,14 +2,14 @@ import { Resolver, Query, Mutation, Args, ID, Int, ResolveField, Parent } from '
 import { SOW, SOWStatus } from './sow.model';
 import { SOWService } from './sow.service';
 import { SowVersionService } from './sow-version.service';
-import { SowVersion, SowCalculatedValue } from './sow-version.model';
+import { SowVersion, SowCalculatedValue, SowVersionService as SowVersionServiceLine } from './sow-version.model';
 import { CreateSOWInput } from './dto/create-sow.input';
 import { UpdateSOWInput } from './dto/update-sow.input';
 import { SubmitSOWSignatureInput } from './dto/submit-sow-signature.input';
 import { SaveSowVersionInput } from './dto/save-sow-version.input';
 import { SignSowInput } from './dto/sign-sow.input';
 import { SowInputsInput } from './dto/sow-inputs.input';
-import { Job } from '../job/job.model';
+import { Job, CustomerCategory } from '../job/job.model';
 import { JobService } from '../job/job.service';
 import { UseGuards, NotFoundException } from '@nestjs/common';
 import { AuthRolesGuard } from '../auth/auth.guard';
@@ -106,6 +106,27 @@ export class SOWResolver {
   @ResolveField(() => Job, { description: 'Job this SOW is associated with' })
   async job(@Parent() sow: SOW): Promise<Job | null> {
     return this.jobService.findById(sow.jobId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Live Fee Schedule figures — recomputed fresh on every query, independent of
+  // whatever is stored on the SOW or frozen into a version. What the "Stale"
+  // chip and Recalculate button on the Fee Schedule compare local edits against.
+  // ---------------------------------------------------------------------------
+
+  @ResolveField(() => [SowVersionServiceLine], {
+    description:
+      'The SOW\'s current service lines and their costs, read fresh on every query. Kept in sync with the job\'s services/category by syncSowServicesFromJobWorkflows — this is what the Fee Schedule "Stale" chip and Recalculate compare a local draft against.'
+  })
+  async liveServices(@Parent() sow: SOW): Promise<SowVersionServiceLine[]> {
+    const job = await this.jobService.findById(sow.jobId);
+    return SowVersionService.deriveInputs(sow, job).services;
+  }
+
+  @ResolveField(() => CustomerCategory, { nullable: true, description: "The job's current pricing category — may differ from what a stale local draft has." })
+  async liveCustomerCategory(@Parent() sow: SOW): Promise<CustomerCategory | null> {
+    const job = await this.jobService.findById(sow.jobId);
+    return job?.customerCategory ?? null;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/sow/sow.resolver.ts
+++ b/src/sow/sow.resolver.ts
@@ -1,62 +1,95 @@
-import { Resolver, Query, Mutation, Args, ID, ResolveField, Parent } from '@nestjs/graphql';
+import { Resolver, Query, Mutation, Args, ID, Int, ResolveField, Parent } from '@nestjs/graphql';
 import { SOW, SOWStatus } from './sow.model';
 import { SOWService } from './sow.service';
+import { SowVersionService } from './sow-version.service';
+import { SowVersion, SowCalculatedValue } from './sow-version.model';
 import { CreateSOWInput } from './dto/create-sow.input';
 import { UpdateSOWInput } from './dto/update-sow.input';
 import { SubmitSOWSignatureInput } from './dto/submit-sow-signature.input';
+import { SaveSowVersionInput } from './dto/save-sow-version.input';
+import { SignSowInput } from './dto/sign-sow.input';
+import { SowInputsInput } from './dto/sow-inputs.input';
 import { Job } from '../job/job.model';
 import { JobService } from '../job/job.service';
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, NotFoundException } from '@nestjs/common';
 import { AuthRolesGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/user.decorator';
 import { User } from '../auth/user.interface';
+import { Roles } from '../auth/roles/roles.decorator';
+import { Role } from '../auth/roles/roles.enum';
+import { assertCanReadSow, assertJobOwner, canSeeAllVersions, isStaff } from './sow-access';
 
 @Resolver(() => SOW)
+@UseGuards(AuthRolesGuard)
 export class SOWResolver {
-  constructor(private readonly sowService: SOWService, private readonly jobService: JobService) {}
+  constructor(private readonly sowService: SOWService, private readonly jobService: JobService, private readonly sowVersionService: SowVersionService) {}
 
-  @Query(() => SOW, { nullable: true, description: 'Get SOW by ID' })
-  async sowById(@Args('id', { type: () => ID }) id: string): Promise<SOW | null> {
-    return this.sowService.findById(id);
+  /**
+   * Loads a SOW and checks the caller may see it. Every version query and
+   * mutation goes through here, so access is decided in one place rather than
+   * repeated per resolver.
+   */
+  private async authorizedSow(sowId: string, user: User): Promise<SOW> {
+    const sow = await this.sowService.findById(sowId);
+    if (!sow) throw new NotFoundException(`SOW with ID ${sowId} not found`);
+    assertCanReadSow(await this.jobService.findById(sow.jobId), user);
+    return sow;
   }
 
-  @Query(() => SOW, { nullable: true, description: 'Get SOW by job ID' })
-  async sowByJobId(@Args('jobId', { type: () => ID }) jobId: string): Promise<SOW | null> {
-    return this.sowService.findByJobId(jobId);
+  private static author(user: User): { sub: string; name: string } {
+    return { sub: user.sub, name: user.preferred_username || user.email || user.sub };
   }
 
-  @Query(() => [SOW], { description: 'Get all SOWs by status' })
+  @Query(() => SOW, { nullable: true, description: 'Get SOW by ID. Staff can view any; clients can view their own.' })
+  async sowById(@Args('id', { type: () => ID }) id: string, @CurrentUser() user: User): Promise<SOW | null> {
+    const sow = await this.sowService.findById(id);
+    if (!sow) return null;
+    assertCanReadSow(await this.jobService.findById(sow.jobId), user);
+    return sow;
+  }
+
+  @Query(() => SOW, { nullable: true, description: 'Get SOW by job ID. Staff can view any; clients can view their own.' })
+  async sowByJobId(@Args('jobId', { type: () => ID }) jobId: string, @CurrentUser() user: User): Promise<SOW | null> {
+    const sow = await this.sowService.findByJobId(jobId);
+    if (!sow) return null;
+    assertCanReadSow(await this.jobService.findById(jobId), user);
+    return sow;
+  }
+
+  @Query(() => [SOW], { description: 'Staff-only. Get all SOWs by status.' })
+  @Roles(Role.DamplabStaff)
   async sowsByStatus(@Args('status', { type: () => SOWStatus }) status: SOWStatus): Promise<SOW[]> {
     return this.sowService.findByStatus(status);
   }
 
-  @Query(() => [SOW], { description: 'Get all SOWs' })
+  @Query(() => [SOW], { description: 'Staff-only. Get all SOWs.' })
+  @Roles(Role.DamplabStaff)
   async allSOWs(): Promise<SOW[]> {
     return this.sowService.findAll();
   }
 
-  @Mutation(() => SOW, { description: 'Create a new SOW' })
-  @UseGuards(AuthRolesGuard)
+  @Mutation(() => SOW, { description: 'Staff-only. Create a new SOW.' })
+  @Roles(Role.DamplabStaff)
   async createSOW(@Args('input', { type: () => CreateSOWInput }) input: CreateSOWInput, @CurrentUser() user: User): Promise<SOW> {
     // Use user email or preferred_username as createdBy if not provided
     const createdBy = input.createdBy || user.email || user.preferred_username || 'unknown';
     return this.sowService.create({ ...input, createdBy });
   }
 
-  @Mutation(() => SOW, { description: 'Update an existing SOW' })
-  @UseGuards(AuthRolesGuard)
+  @Mutation(() => SOW, { description: 'Staff-only. Update an existing SOW.' })
+  @Roles(Role.DamplabStaff)
   async updateSOW(@Args('id', { type: () => ID }) id: string, @Args('input', { type: () => UpdateSOWInput }) input: UpdateSOWInput): Promise<SOW> {
     return this.sowService.update(id, input);
   }
 
-  @Mutation(() => Boolean, { description: 'Delete a SOW' })
-  @UseGuards(AuthRolesGuard)
+  @Mutation(() => Boolean, { description: 'Staff-only. Delete a SOW.' })
+  @Roles(Role.DamplabStaff)
   async deleteSOW(@Args('id', { type: () => ID }) id: string): Promise<boolean> {
     return this.sowService.delete(id);
   }
 
-  @Mutation(() => SOW, { description: 'Create or update SOW for a job (upsert)' })
-  @UseGuards(AuthRolesGuard)
+  @Mutation(() => SOW, { description: 'Staff-only. Create or update SOW for a job (upsert).' })
+  @Roles(Role.DamplabStaff)
   async upsertSOWForJob(@Args('jobId', { type: () => ID }) jobId: string, @Args('input', { type: () => CreateSOWInput }) input: CreateSOWInput, @CurrentUser() user: User): Promise<SOW> {
     // Use user email or preferred_username as createdBy if not provided
     const createdBy = input.createdBy || user.email || user.preferred_username || 'unknown';
@@ -64,9 +97,8 @@ export class SOWResolver {
   }
 
   @Mutation(() => SOW, {
-    description: 'Submit a signature for an SOW (client or technician). Idempotent per role.'
+    description: 'Submit a signature for an SOW (client or technician). Idempotent per role; the service checks job ownership for CLIENT and staff role for TECHNICIAN.'
   })
-  @UseGuards(AuthRolesGuard)
   async submitSOWSignature(@Args('input', { type: () => SubmitSOWSignatureInput }) input: SubmitSOWSignatureInput, @CurrentUser() user: User): Promise<SOW> {
     return this.sowService.submitSignature(input, user);
   }
@@ -74,5 +106,108 @@ export class SOWResolver {
   @ResolveField(() => Job, { description: 'Job this SOW is associated with' })
   async job(@Parent() sow: SOW): Promise<Job | null> {
     return this.jobService.findById(sow.jobId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Versioned document
+  // ---------------------------------------------------------------------------
+
+  @ResolveField(() => SowVersion, { nullable: true, description: 'Latest version — what staff edit. May be an unsent draft.' })
+  async currentVersion(@Parent() sow: SOW, @CurrentUser() user: User): Promise<SowVersion | null> {
+    // Customers must not see drafts, so they get the version in force instead.
+    if (!isStaff(user)) return this.sowVersionService.getActiveVersion(String((sow as any)._id));
+    return this.sowVersionService.getCurrentVersion(String((sow as any)._id));
+  }
+
+  @ResolveField(() => SowVersion, { nullable: true, description: 'Version currently in force with the customer' })
+  async activeVersion(@Parent() sow: SOW): Promise<SowVersion | null> {
+    return this.sowVersionService.getActiveVersion(String((sow as any)._id));
+  }
+
+  @ResolveField(() => [SowVersion], { description: 'Version history, newest first. Staff see every version; customers see only those issued to them.' })
+  async versions(@Parent() sow: SOW, @CurrentUser() user: User): Promise<SowVersion[]> {
+    return this.sowVersionService.listVersions(String((sow as any)._id), { visibleOnly: !canSeeAllVersions(user) });
+  }
+
+  @Query(() => [SowVersion], { description: 'Version history for a SOW, newest first. Staff see every version; customers see only those issued to them.' })
+  async sowVersions(@Args('sowId', { type: () => ID }) sowId: string, @CurrentUser() user: User): Promise<SowVersion[]> {
+    await this.authorizedSow(sowId, user);
+    return this.sowVersionService.listVersions(sowId, { visibleOnly: !canSeeAllVersions(user) });
+  }
+
+  @Query(() => SowVersion, { nullable: true, description: 'One version of a SOW. Customers may only read versions issued to them.' })
+  async sowVersion(@Args('sowId', { type: () => ID }) sowId: string, @Args('versionNumber', { type: () => Int }) versionNumber: number, @CurrentUser() user: User): Promise<SowVersion | null> {
+    await this.authorizedSow(sowId, user);
+    const version = await this.sowVersionService.getVersion(sowId, versionNumber);
+    if (!version) return null;
+    if (!canSeeAllVersions(user) && !version.visibleToCustomer) return null;
+    return version;
+  }
+
+  @Query(() => [SowCalculatedValue], {
+    description: 'Staff-only. Recomputes the generated text for the given inputs without saving. Returns generated values only — the editor keeps its own overrides and enable flags.'
+  })
+  @Roles(Role.DamplabStaff)
+  async sowFieldPreview(@Args('sowId', { type: () => ID }) sowId: string, @Args('inputs', { type: () => SowInputsInput }) inputs: SowInputsInput): Promise<SowCalculatedValue[]> {
+    return this.sowVersionService.previewCalculatedValues(sowId, inputs);
+  }
+
+  @Mutation(() => SowVersion, { description: 'Staff-only. Saves edits as a new draft. Does not change what the customer sees.' })
+  @Roles(Role.DamplabStaff)
+  async saveSowVersion(
+    @Args('sowId', { type: () => ID }) sowId: string,
+    @Args('input', { type: () => SaveSowVersionInput }) input: SaveSowVersionInput,
+    @CurrentUser() user: User
+  ): Promise<SowVersion> {
+    await this.authorizedSow(sowId, user);
+    return this.sowVersionService.saveVersion(sowId, input, SOWResolver.author(user));
+  }
+
+  @Mutation(() => SOW, { description: 'Staff-only. Discards an unsent draft above the active version.' })
+  @Roles(Role.DamplabStaff)
+  async discardSowDraft(@Args('sowId', { type: () => ID }) sowId: string, @Args('versionNumber', { type: () => Int }) versionNumber: number, @CurrentUser() user: User): Promise<SOW> {
+    await this.authorizedSow(sowId, user);
+    return this.sowVersionService.discardDraft(sowId, versionNumber);
+  }
+
+  @Mutation(() => SowVersion, { description: 'Staff-only. Issues the current draft to the customer for signing.' })
+  @Roles(Role.DamplabStaff)
+  async sendSowToCustomer(@Args('sowId', { type: () => ID }) sowId: string, @CurrentUser() user: User): Promise<SowVersion> {
+    await this.authorizedSow(sowId, user);
+    return this.sowVersionService.sendToCustomer(sowId, SOWResolver.author(user));
+  }
+
+  @Mutation(() => SowVersion, { description: 'Job owner only. Records the customer signature on the version in force.' })
+  async signSow(@Args('sowId', { type: () => ID }) sowId: string, @Args('input', { type: () => SignSowInput }) input: SignSowInput, @CurrentUser() user: User): Promise<SowVersion> {
+    const sow = await this.authorizedSow(sowId, user);
+    // Signing records the customer's own assent, so staff cannot stand in for them.
+    assertJobOwner(await this.jobService.findById(sow.jobId), user);
+    return this.sowVersionService.sign(sowId, input, user);
+  }
+
+  @Mutation(() => SowVersion, { description: 'Staff-only. Countersigns a signed SOW and locks it as FINAL.' })
+  @Roles(Role.DamplabStaff)
+  async finalizeSow(@Args('sowId', { type: () => ID }) sowId: string, @Args('name') name: string, @CurrentUser() user: User): Promise<SowVersion> {
+    await this.authorizedSow(sowId, user);
+    return this.sowVersionService.finalize(sowId, name, SOWResolver.author(user));
+  }
+
+  @Mutation(() => SowVersion, { description: 'Staff-only. Cancels the SOW.' })
+  @Roles(Role.DamplabStaff)
+  async cancelSow(
+    @Args('sowId', { type: () => ID }) sowId: string,
+    // Explicit type: an optional parameter erases to `undefined` at runtime, so
+    // the schema builder cannot infer String on its own.
+    @Args('note', { type: () => String, nullable: true }) note: string | undefined,
+    @CurrentUser() user: User
+  ): Promise<SowVersion> {
+    await this.authorizedSow(sowId, user);
+    return this.sowVersionService.cancel(sowId, note, SOWResolver.author(user));
+  }
+
+  @Mutation(() => SOW, { description: 'Adds a question to the SOW thread. The job owner or staff may post.' })
+  async askSowQuestion(@Args('sowId', { type: () => ID }) sowId: string, @Args('text') text: string, @CurrentUser() user: User): Promise<SOW> {
+    await this.authorizedSow(sowId, user);
+    return this.sowVersionService.addQuestion(sowId, text, { ...SOWResolver.author(user), isStaff: isStaff(user) });
   }
 }

--- a/src/sow/sow.resolver.ts
+++ b/src/sow/sow.resolver.ts
@@ -204,10 +204,4 @@ export class SOWResolver {
     await this.authorizedSow(sowId, user);
     return this.sowVersionService.cancel(sowId, note, SOWResolver.author(user));
   }
-
-  @Mutation(() => SOW, { description: 'Adds a question to the SOW thread. The job owner or staff may post.' })
-  async askSowQuestion(@Args('sowId', { type: () => ID }) sowId: string, @Args('text') text: string, @CurrentUser() user: User): Promise<SOW> {
-    await this.authorizedSow(sowId, user);
-    return this.sowVersionService.addQuestion(sowId, text, { ...SOWResolver.author(user), isStaff: isStaff(user) });
-  }
 }

--- a/src/sow/sow.service.ts
+++ b/src/sow/sow.service.ts
@@ -11,6 +11,7 @@ import { User } from '../auth/user.interface';
 import { Role } from '../auth/roles/roles.enum';
 import { DampLabServices } from '../services/damplab-services.services';
 import { calculateServiceCost, CustomerCategory } from '../pricing/service-pricing.util';
+import { SowVersionService } from './sow-version.service';
 
 @Injectable()
 export class SOWService {
@@ -18,7 +19,11 @@ export class SOWService {
     @InjectModel(SOW.name) private readonly sowModel: Model<SOWDocument>,
     private readonly dampLabServices: DampLabServices,
     @Inject(forwardRef(() => JobService))
-    private readonly jobService: JobService
+    private readonly jobService: JobService,
+    // Circular by design: SOWService creates version 1, and SowVersionService
+    // writes billing changes back through SOWService. Both sides need forwardRef.
+    @Inject(forwardRef(() => SowVersionService))
+    private readonly sowVersionService: SowVersionService
   ) {}
 
   /**
@@ -39,29 +44,41 @@ export class SOWService {
     return this.generateSOWNumber();
   }
 
+  /** The numeric part of a SOW number, or null if it does not parse. */
+  static parseSowNumber(sowNumber: unknown): number | null {
+    if (typeof sowNumber !== 'string') return null;
+    const match = sowNumber.match(/SOW\s+(\d+)/i);
+    if (!match) return null;
+    const n = parseInt(match[1], 10);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  /** Every SOW number uses this width, so ordering and formatting stay consistent. */
+  static formatSowNumber(n: number): string {
+    return `SOW ${String(n).padStart(5, '0')}`;
+  }
+
   /**
-   * Generate the next SOW number in sequence (e.g., "SOW 001", "SOW 002")
+   * Next SOW number in sequence.
+   *
+   * The highest existing number is found numerically, not by sorting the strings.
+   * A string sort over mixed widths ranks "SOW 013" above "SOW 00099", so the old
+   * implementation could pick a lower number as the maximum and hand back one that
+   * was already taken — which the unique index then rejects, failing SOW creation
+   * outright. Numbers are also emitted at one consistent width now; the two
+   * formats that used to coexist were what made the sort ambiguous.
    */
   async generateSOWNumber(): Promise<string> {
-    // Find the highest SOW number
-    const lastSOW = await this.sowModel.findOne({}).sort({ sowNumber: -1 }).exec();
+    const existing = await this.sowModel.find({}, { sowNumber: 1 }).lean().exec();
+    const numbers = existing.map((s) => SOWService.parseSowNumber((s as { sowNumber?: string }).sowNumber)).filter((n): n is number => n !== null);
+    let next = (numbers.length ? Math.max(...numbers) : 0) + 1;
 
-    if (!lastSOW) {
-      return 'SOW 001';
-    }
+    // Defensive: legacy rows whose number does not parse are invisible above, so
+    // step past anything already taken rather than colliding on the unique index.
+    const taken = new Set(existing.map((s) => (s as { sowNumber?: string }).sowNumber));
+    while (taken.has(SOWService.formatSowNumber(next))) next += 1;
 
-    // Extract the number from the last SOW number (e.g., "SOW 059" -> 59)
-    const match = lastSOW.sowNumber.match(/SOW\s+(\d+)/i);
-    if (!match) {
-      // If format is unexpected, start from 001
-      return 'SOW 001';
-    }
-
-    const lastNumber = parseInt(match[1], 10);
-    const nextNumber = lastNumber + 1;
-
-    // Format with zero padding (e.g., 1 -> "001", 59 -> "059")
-    return `SOW ${nextNumber.toString().padStart(3, '0')}`;
+    return SOWService.formatSowNumber(next);
   }
 
   /**
@@ -189,6 +206,158 @@ export class SOWService {
   }
 
   /**
+   * The job a SOW belongs to, or null. Callers need it for the customer category
+   * (which drives pricing) and the display job id shown on the document.
+   */
+  async getJobForSow(sow: Pick<SOW, 'jobId'>): Promise<Job | null> {
+    if (!sow?.jobId) return null;
+    return this.jobService.findById(String(sow.jobId));
+  }
+
+  /**
+   * Writes the billing figures a staff member changed in the SOW editor back to
+   * the billing core, then recomputes the totals.
+   *
+   * Deliberately does not go through transformServices. That helper reprices each
+   * line from the service record plus the node's formData, and the document editor
+   * has no formData to give it — so routing a document save through it would drop
+   * the run-count multiplier and reprice a 70-run job as a 1-run job. Here the
+   * cost the staff member sees is the cost that is stored; only baseCost and
+   * totalCost are derived, and only from values already on the SOW.
+   *
+   * Costs are matched by serviceId and applied only to lines that already exist,
+   * so a document save can never add or remove a billable line — that remains the
+   * job of the workflow sync.
+   */
+  async applyDocumentBilling(sowId: string, changes: { serviceCosts?: Array<{ serviceId: string; cost: number }>; adjustments?: CreateSOWInput['pricing']['adjustments'] }): Promise<SOW> {
+    const sow = await this.sowModel.findById(sowId).exec();
+    if (!sow) throw new NotFoundException(`SOW with ID ${sowId} not found`);
+
+    const costByServiceId = new Map((changes.serviceCosts ?? []).map((s) => [String(s.serviceId), Number(s.cost)]));
+
+    const services = (sow.services ?? []).map((service) => {
+      const override = costByServiceId.get(String(service.serviceId ?? service._id));
+      if (override === undefined || !Number.isFinite(override) || override < 0) return service;
+      return { ...service, cost: override };
+    });
+
+    const adjustments = changes.adjustments ? this.transformPricingAdjustments(changes.adjustments) : sow.pricing?.adjustments ?? [];
+
+    const baseCost = this.calculateBaseCost(services);
+    const totalCost = this.calculateTotalCost(baseCost, adjustments);
+
+    const updated = await this.sowModel
+      .findByIdAndUpdate(sowId, { $set: { services, pricing: { ...(sow.pricing ?? {}), baseCost, adjustments, totalCost }, updatedAt: new Date() } }, { new: true })
+      .exec();
+
+    if (!updated) throw new NotFoundException(`SOW with ID ${sowId} not found`);
+    return updated;
+  }
+
+  /** Default project length when nothing better is known; staff edit it in the editor. */
+  private static readonly DEFAULT_DURATION_DAYS = 14;
+
+  /**
+   * Opening scope-of-work lines: one per distinct service on the job.
+   *
+   * These are a starting point, not a finished document — every line is editable
+   * in the SOW editor. What matters is that a newly generated SOW is never empty,
+   * because `validateSOWData` rejects an empty scope outright.
+   */
+  private static buildScopeOfWork(services: CreateSOWInput['services']): string[] {
+    const counts = new Map<string, { name: string; count: number }>();
+    for (const service of services) {
+      const entry = counts.get(service.id);
+      if (entry) entry.count += 1;
+      else counts.set(service.id, { name: service.name, count: 1 });
+    }
+
+    const lines = [...counts.values()].map(({ name, count }) => (count > 1 ? `Perform ${name} (${count} instances)` : `Perform ${name}`));
+    return lines.length ? lines : ['Perform molecular biology services as specified in the workflow'];
+  }
+
+  /**
+   * Opening deliverables, taken from each service record's own `deliverables`.
+   *
+   * Most seeded services carry none, hence the fallback: an empty array would
+   * fail validation and turn "Generate SOW" into an error message.
+   */
+  private async buildDeliverables(services: CreateSOWInput['services']): Promise<string[]> {
+    const deliverables = new Set<string>();
+
+    for (const id of new Set(services.map((s) => s.id))) {
+      const record = await this.dampLabServices.findOne(id);
+      for (const deliverable of (record as { deliverables?: string[] } | null)?.deliverables ?? []) {
+        if (typeof deliverable === 'string' && deliverable.trim()) deliverables.add(deliverable.trim());
+      }
+    }
+
+    if (deliverables.size === 0) {
+      deliverables.add('Completed molecular biology services as specified');
+      deliverables.add('Quality control results');
+    }
+
+    return [...deliverables];
+  }
+
+  /**
+   * Create the first SOW for a job, deriving everything from the job itself.
+   *
+   * This is what "Generate SOW" calls. The old flow built the whole payload in the
+   * browser and posted it; the document text now comes from the server, so the
+   * client sends nothing but the job id and the server decides what the opening
+   * draft says.
+   *
+   * Idempotent: a job that already has a SOW gets that SOW back rather than an
+   * error, so a double click cannot produce a failure the staff member has to
+   * interpret.
+   *
+   * `services` comes from the caller because walking the job's workflows down to
+   * their nodes belongs to the workflow layer, not here. Each entry must carry the
+   * node's `formData` — that is what the price multiplier is read from, and
+   * dropping it silently reprices a 70-run job as a single run.
+   */
+  async createForJob(jobId: string, services: CreateSOWInput['services'], createdBy: string): Promise<SOW> {
+    const existing = await this.sowModel.findOne({ jobId }).exec();
+    if (existing) return existing;
+
+    const job = await this.jobService.findById(jobId);
+    if (!job) {
+      throw new NotFoundException(`Job with ID ${jobId} not found`);
+    }
+
+    if (!services.length) {
+      throw new BadRequestException('This job has no services yet, so there is nothing to put in a Statement of Work. Add a workflow to the job first.');
+    }
+
+    const startDate = new Date();
+    const endDate = new Date(startDate);
+    endDate.setDate(endDate.getDate() + SOWService.DEFAULT_DURATION_DAYS);
+
+    return this.create({
+      jobId,
+      // sowTitle is deliberately absent: the field calculator supplies the default
+      // title, and a second copy of that string here is exactly the divergence the
+      // document rewrite exists to prevent.
+      clientName: (job as any).clientDisplayName || job.username || job.name || 'Client',
+      clientEmail: job.email,
+      clientInstitution: job.institute,
+      clientAddress: job.institute,
+      scopeOfWork: SOWService.buildScopeOfWork(services),
+      deliverables: await this.buildDeliverables(services),
+      services,
+      timeline: { startDate, endDate, duration: `${SOWService.DEFAULT_DURATION_DAYS} days` },
+      resources: { projectManager: '', projectLead: '' },
+      // baseCost and totalCost are left out on purpose: `create` computes both from
+      // the service records and only validates figures the caller actually supplied.
+      pricing: { adjustments: [] },
+      additionalInformation: '',
+      createdBy,
+      status: SOWStatus.DRAFT
+    });
+  }
+
+  /**
    * Create a new SOW
    */
   async create(createSOWInput: CreateSOWInput): Promise<SOW> {
@@ -251,7 +420,12 @@ export class SOWService {
     };
 
     const sow = await this.sowModel.create(sowData);
-    return sow;
+    // Every SOW owns a document from the moment it exists, so the editor and the
+    // customer view never have to cope with a SOW that has no version.
+    await this.sowVersionService.createInitialVersion(sow, job as any, createSOWInput.createdBy);
+    // Re-read: creating the version sets the version pointers with a separate
+    // update, so the document created above still reports currentVersionNumber 0.
+    return (await this.sowModel.findById(sow._id).exec()) ?? sow;
   }
 
   /**

--- a/src/sow/sow.service.ts
+++ b/src/sow/sow.service.ts
@@ -10,7 +10,7 @@ import { Job } from '../job/job.model';
 import { User } from '../auth/user.interface';
 import { Role } from '../auth/roles/roles.enum';
 import { DampLabServices } from '../services/damplab-services.services';
-import { calculateServiceCost, CustomerCategory } from '../pricing/service-pricing.util';
+import { calculateServiceCost, extractRunCount, CustomerCategory } from '../pricing/service-pricing.util';
 import { SowVersionService } from './sow-version.service';
 
 @Injectable()
@@ -151,13 +151,15 @@ export class SOWService {
           throw new NotFoundException(`Service with ID ${service.id} not found`);
         }
         const cost = calculateServiceCost(serviceRecord, service.formData, service.cost, customerCategory);
+        const runCount = extractRunCount(service.formData);
         return {
           _id: service.id,
           serviceId: service.id,
           name: service.name,
           description: service.description,
           cost,
-          category: service.category
+          category: service.category,
+          runCount
         };
       })
     );
@@ -225,19 +227,32 @@ export class SOWService {
    * cost the staff member sees is the cost that is stored; only baseCost and
    * totalCost are derived, and only from values already on the SOW.
    *
-   * Costs are matched by serviceId and applied only to lines that already exist,
-   * so a document save can never add or remove a billable line — that remains the
-   * job of the workflow sync.
+   * Costs are matched by position, not serviceId — a job can legitimately use the
+   * same catalogue service more than once (e.g. two PCR steps at different run
+   * counts), so serviceId is not unique per line. A serviceId-keyed override map
+   * would collapse every line sharing that id onto whichever cost came last in
+   * the request, corrupting the other lines' totals. The editor never adds,
+   * removes, or reorders lines — SowFieldSourceControls only edits the cost
+   * already at a given index — so position is the reliable correlation key here,
+   * same as collectSowServiceInputs already assumes elsewhere. If the arrays
+   * have diverged (e.g. a workflow sync changed the billable lines while the
+   * editor was open) a line is left unchanged rather than risk writing its cost
+   * onto the wrong service — that's what "applied only to lines that already
+   * exist" means in practice.
    */
   async applyDocumentBilling(sowId: string, changes: { serviceCosts?: Array<{ serviceId: string; cost: number }>; adjustments?: CreateSOWInput['pricing']['adjustments'] }): Promise<SOW> {
     const sow = await this.sowModel.findById(sowId).exec();
     if (!sow) throw new NotFoundException(`SOW with ID ${sowId} not found`);
 
-    const costByServiceId = new Map((changes.serviceCosts ?? []).map((s) => [String(s.serviceId), Number(s.cost)]));
+    const incoming = changes.serviceCosts ?? [];
+    const sameLength = incoming.length === (sow.services ?? []).length;
 
-    const services = (sow.services ?? []).map((service) => {
-      const override = costByServiceId.get(String(service.serviceId ?? service._id));
-      if (override === undefined || !Number.isFinite(override) || override < 0) return service;
+    const services = (sow.services ?? []).map((service, i) => {
+      if (!sameLength) return service;
+      const line = incoming[i];
+      if (String(line.serviceId) !== String(service.serviceId ?? service._id)) return service;
+      const override = Number(line.cost);
+      if (!Number.isFinite(override) || override < 0) return service;
       return { ...service, cost: override };
     });
 

--- a/src/station/station.service.ts
+++ b/src/station/station.service.ts
@@ -13,7 +13,10 @@ export class StationService {
   }
 
   async findAll(includeDeleted = false): Promise<Station[]> {
-    return this.model.find(includeDeleted ? {} : { isDeleted: { $ne: true } }).sort({ name: 1 }).exec();
+    return this.model
+      .find(includeDeleted ? {} : { isDeleted: { $ne: true } })
+      .sort({ name: 1 })
+      .exec();
   }
 
   async findById(id: string): Promise<Station | null> {

--- a/src/template/template.resolver.ts
+++ b/src/template/template.resolver.ts
@@ -3,7 +3,6 @@ import { Template } from './template.model';
 import { TemplateService } from './template.service';
 import { CreateTemplateInput } from './dto/create-template.input';
 import { UpdateTemplateInput } from './dto/update-template.input';
-import { NotFoundException } from '@nestjs/common';
 
 @Resolver(() => Template)
 export class TemplateResolver {

--- a/src/usage-billing/usage-billing.resolver.ts
+++ b/src/usage-billing/usage-billing.resolver.ts
@@ -15,10 +15,7 @@ import { User } from '../auth/user.interface';
 @UseGuards(AuthRolesGuard)
 @Roles(Role.DamplabStaff)
 export class UsageBillingResolver {
-  constructor(
-    private readonly usageBillingService: UsageBillingService,
-    private readonly bookingService: BookingService
-  ) {}
+  constructor(private readonly usageBillingService: UsageBillingService, private readonly bookingService: BookingService) {}
 
   @Query(() => [BillableOwner], { description: 'Users with confirmed, unbilled inventory usage.' })
   async billableOwners(): Promise<BillableOwner[]> {

--- a/src/usage-billing/usage-billing.service.ts
+++ b/src/usage-billing/usage-billing.service.ts
@@ -1,21 +1,13 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import {
-  UsageBillingResult,
-  UsageInvoice,
-  UsageInvoiceDocument,
-  UsageLineItem,
-  UsageSow,
-  UsageSowDocument
-} from './usage-billing.model';
+import { UsageBillingResult, UsageInvoice, UsageInvoiceDocument, UsageLineItem, UsageSow, UsageSowDocument } from './usage-billing.model';
 import { GenerateUsageBillingInput } from './dtos/usage-billing.dto';
 import { BookingService } from '../booking/booking.service';
 import { Booking, BookingBillingStatus, BookingKind, BookingStatus } from '../booking/booking.model';
 
 const round2 = (n: number): number => Math.round(n * 100) / 100;
-const DEFAULT_TERMS =
-  'Net 30. This statement covers inventory/equipment usage logged at DAMPLab for the period indicated. Rates are applied per the customer category on file.';
+const DEFAULT_TERMS = 'Net 30. This statement covers inventory/equipment usage logged at DAMPLab for the period indicated. Rates are applied per the customer category on file.';
 
 @Injectable()
 export class UsageBillingService {
@@ -46,7 +38,7 @@ export class UsageBillingService {
       bookingId: String(b._id),
       label: b.inventoryName || 'Inventory item',
       detail: this.lineDetail(b),
-      usedAt: (b.usedOn || b.startTime) ? new Date(b.usedOn || b.startTime).toISOString() : undefined,
+      usedAt: b.usedOn || b.startTime ? new Date(b.usedOn || b.startTime).toISOString() : undefined,
       cost: round2(b.cost ?? 0)
     };
   }
@@ -114,11 +106,17 @@ export class UsageBillingService {
   }
 
   async findSows(ownerSub?: string): Promise<UsageSow[]> {
-    return this.sowModel.find(ownerSub ? { billToSub: ownerSub } : {}).sort({ createdAt: -1 }).exec();
+    return this.sowModel
+      .find(ownerSub ? { billToSub: ownerSub } : {})
+      .sort({ createdAt: -1 })
+      .exec();
   }
 
   async findInvoices(ownerSub?: string): Promise<UsageInvoice[]> {
-    return this.invoiceModel.find(ownerSub ? { billToSub: ownerSub } : {}).sort({ createdAt: -1 }).exec();
+    return this.invoiceModel
+      .find(ownerSub ? { billToSub: ownerSub } : {})
+      .sort({ createdAt: -1 })
+      .exec();
   }
 
   async sowById(id: string): Promise<UsageSow | null> {

--- a/src/workflow/dtos/keycloak-customer-user-page.dto.ts
+++ b/src/workflow/dtos/keycloak-customer-user-page.dto.ts
@@ -13,4 +13,3 @@ export class KeycloakUserCustomerManagementPage {
   })
   hasNextPage: boolean;
 }
-

--- a/src/workflow/models/edge.model.ts
+++ b/src/workflow/models/edge.model.ts
@@ -30,8 +30,12 @@ export class WorkflowEdge {
   target: mongoose.Types.ObjectId | WorkflowNode;
 
   @Prop({ type: mongoose.Schema.Types.Mixed })
-  @Field(() => JSON, { description: 'React Flow representation of the graph for re-generating' })
-  reactEdge: any;
+  @Field(() => JSON, {
+    nullable: true,
+    description:
+      'React Flow representation of the edge for re-generating the graph. Nullable for the same reason as WorkflowNode.reactNode: older edges have none, and selecting a non-nullable field would fail the whole query.'
+  })
+  reactEdge?: any;
 }
 
 export type WorkflowEdgeDocument = WorkflowEdge & Document;

--- a/src/workflow/models/node.model.ts
+++ b/src/workflow/models/node.model.ts
@@ -46,8 +46,12 @@ export class WorkflowNode {
   formData: any;
 
   @Prop({ type: mongoose.Schema.Types.Mixed })
-  @Field(() => JSON, { description: 'React Flow representation of the graph for re-generating' })
-  reactNode: JSON;
+  @Field(() => JSON, {
+    nullable: true,
+    description:
+      'React Flow representation of the node (including its canvas position) for re-generating the graph. Nullable: nodes created before this was persisted, or through paths that never set it, have none — and a non-nullable field would make merely selecting it fail the whole job query.'
+  })
+  reactNode?: JSON;
 
   @Prop({ requied: true, default: WorkflowNodeState.QUEUED })
   @Field(() => WorkflowNodeState, { description: 'Where in the process is the current node' })
@@ -76,8 +80,7 @@ export class WorkflowNode {
   @Prop({ type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'InventoryItem' }], required: false, default: [] })
   @Field(() => [String], {
     nullable: true,
-    description:
-      'Inventory items currently held by this node while it is IN_PROGRESS. Cleared automatically on transition out of IN_PROGRESS.'
+    description: 'Inventory items currently held by this node while it is IN_PROGRESS. Cleared automatically on transition out of IN_PROGRESS.'
   })
   usedInventory?: mongoose.Types.ObjectId[];
 

--- a/src/workflow/resolvers/customer-management.resolver.ts
+++ b/src/workflow/resolvers/customer-management.resolver.ts
@@ -25,8 +25,7 @@ export class CustomerManagementResolver {
   constructor(private readonly keycloakService: KeycloakService) {}
 
   @Query(() => KeycloakUserCustomerManagementPage, {
-    description:
-      'Staff: list Keycloak users by staff/customer category group membership, paginated. Intended for customer management UI browsing (default STAFF).'
+    description: 'Staff: list Keycloak users by staff/customer category group membership, paginated. Intended for customer management UI browsing (default STAFF).'
   })
   @UseGuards(AuthRolesGuard)
   @Roles(Role.DamplabStaff)
@@ -36,9 +35,7 @@ export class CustomerManagementResolver {
     @Args('limit', { type: () => Int, nullable: true, defaultValue: 25 }) limit: number
   ): Promise<KeycloakUserCustomerManagementPage> {
     if (!this.keycloakService.isConfigured()) {
-      throw new BadRequestException(
-        'Keycloak Admin API is not configured (KEYCLOAK_SERVER_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET).'
-      );
+      throw new BadRequestException('Keycloak Admin API is not configured (KEYCLOAK_SERVER_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET).');
     }
     const safeOffset = Math.max(offset ?? 0, 0);
     const safeLimit = Math.min(Math.max(limit ?? 25, 1), 100);
@@ -60,10 +57,10 @@ export class CustomerManagementResolver {
         category === CustomerManagementUserListCategory.INTERNAL_CUSTOMERS
           ? Role.InternalCustomers
           : category === CustomerManagementUserListCategory.EXTERNAL_CUSTOMER_ACADEMIC
-            ? Role.ExternalCustomerAcademic
-            : category === CustomerManagementUserListCategory.EXTERNAL_CUSTOMER_MARKET
-              ? Role.ExternalCustomerMarket
-              : Role.ExternalCustomerNoSalary;
+          ? Role.ExternalCustomerAcademic
+          : category === CustomerManagementUserListCategory.EXTERNAL_CUSTOMER_MARKET
+          ? Role.ExternalCustomerMarket
+          : Role.ExternalCustomerNoSalary;
       rows = await this.keycloakService.listUsersInGroupWithCustomerCategory(groupName, first, max);
     }
 
@@ -75,8 +72,7 @@ export class CustomerManagementResolver {
   }
 
   @Query(() => [KeycloakUserCustomerManagement], {
-    description:
-      'Staff: search Keycloak users by name/email/username and return inferred customer pricing category from group membership.'
+    description: 'Staff: search Keycloak users by name/email/username and return inferred customer pricing category from group membership.'
   })
   @UseGuards(AuthRolesGuard)
   @Roles(Role.DamplabStaff)
@@ -85,9 +81,7 @@ export class CustomerManagementResolver {
     @Args('max', { type: () => Int, nullable: true, defaultValue: 25 }) max: number
   ): Promise<KeycloakUserCustomerManagement[]> {
     if (!this.keycloakService.isConfigured()) {
-      throw new BadRequestException(
-        'Keycloak Admin API is not configured (KEYCLOAK_SERVER_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET).'
-      );
+      throw new BadRequestException('Keycloak Admin API is not configured (KEYCLOAK_SERVER_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET).');
     }
     const trimmed = (search ?? '').trim();
     if (trimmed.length < 2) {
@@ -98,8 +92,7 @@ export class CustomerManagementResolver {
   }
 
   @Mutation(() => KeycloakUserCustomerManagement, {
-    description:
-      'Staff: set a user’s Keycloak pricing customer group to match the given category, or clear all such groups when category is omitted.'
+    description: 'Staff: set a user’s Keycloak pricing customer group to match the given category, or clear all such groups when category is omitted.'
   })
   @UseGuards(AuthRolesGuard)
   @Roles(Role.DamplabStaff)
@@ -108,9 +101,7 @@ export class CustomerManagementResolver {
     @Args('category', { type: () => CustomerCategory, nullable: true }) category: CustomerCategory | null
   ): Promise<KeycloakUserCustomerManagement> {
     if (!this.keycloakService.isConfigured()) {
-      throw new BadRequestException(
-        'Keycloak Admin API is not configured (KEYCLOAK_SERVER_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET).'
-      );
+      throw new BadRequestException('Keycloak Admin API is not configured (KEYCLOAK_SERVER_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET).');
     }
     try {
       await this.keycloakService.setUserCustomerCategory(userId, category ?? null);

--- a/src/workflow/resolvers/node.resolver.ts
+++ b/src/workflow/resolvers/node.resolver.ts
@@ -54,10 +54,7 @@ export class WorkflowNodeResolver {
     @Args('newState', { type: () => WorkflowNodeState }) newState: WorkflowNodeState
   ): Promise<WorkflowNode> {
     const updated = (await this.nodeService.updateState(workflowNode, newState))!;
-    const serviceName =
-      (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) ||
-      (updated as any)?.service?.name ||
-      'Service';
+    const serviceName = (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) || (updated as any)?.service?.name || 'Service';
     await this.activityService.createEvent({
       type: 'LAB_NODE_STATE_CHANGED',
       message: `Moved "${serviceName}" to ${newState}`,
@@ -77,10 +74,7 @@ export class WorkflowNodeResolver {
     @Args('assigneeDisplayName', { type: () => String, nullable: true }) assigneeDisplayName: string | null
   ): Promise<WorkflowNode> {
     const updated = (await this.nodeService.updateAssignee(workflowNode, assigneeId, assigneeDisplayName))!;
-    const serviceName =
-      (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) ||
-      (updated as any)?.service?.name ||
-      'Service';
+    const serviceName = (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) || (updated as any)?.service?.name || 'Service';
     await this.activityService.createEvent({
       type: 'LAB_NODE_ASSIGNED',
       message: assigneeDisplayName ? `Assigned "${serviceName}" to ${assigneeDisplayName}` : `Unassigned "${serviceName}"`,
@@ -101,16 +95,10 @@ export class WorkflowNodeResolver {
     @Args('reservationEnd', { nullable: true }) reservationEnd?: Date
   ): Promise<WorkflowNode> {
     const updated = (await this.nodeService.setUsedInventory(workflowNode, inventoryIds, reservationStart ?? null, reservationEnd ?? null))!;
-    const serviceName =
-      (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) ||
-      (updated as any)?.service?.name ||
-      'Service';
+    const serviceName = (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) || (updated as any)?.service?.name || 'Service';
     await this.activityService.createEvent({
       type: 'LAB_NODE_INVENTORY_SET',
-      message:
-        inventoryIds.length > 0
-          ? `Set inventory on "${serviceName}" (${inventoryIds.length} item${inventoryIds.length === 1 ? '' : 's'})`
-          : `Cleared inventory on "${serviceName}"`,
+      message: inventoryIds.length > 0 ? `Set inventory on "${serviceName}" (${inventoryIds.length} item${inventoryIds.length === 1 ? '' : 's'})` : `Cleared inventory on "${serviceName}"`,
       actorDisplayName: undefined,
       workflowNodeId: String(updated._id),
       serviceName
@@ -148,10 +136,7 @@ export class WorkflowNodeResolver {
     @Args('estimatedMinutes', { type: () => Float, nullable: true }) estimatedMinutes: number | null
   ): Promise<WorkflowNode> {
     const updated = (await this.nodeService.updateEstimatedMinutes(workflowNode, estimatedMinutes))!;
-    const serviceName =
-      (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) ||
-      (updated as any)?.service?.name ||
-      'Service';
+    const serviceName = (typeof (updated as any)?.label === 'string' && String((updated as any).label).trim()) || (updated as any)?.service?.name || 'Service';
     await this.activityService.createEvent({
       type: 'LAB_NODE_ESTIMATE_UPDATED',
       message: estimatedMinutes != null ? `Updated estimate for "${serviceName}" to ${estimatedMinutes} min` : `Cleared estimate for "${serviceName}"`,

--- a/src/workflow/services/node.service.spec.ts
+++ b/src/workflow/services/node.service.spec.ts
@@ -1,0 +1,57 @@
+import { WorkflowNodeService } from './node.service';
+
+/**
+ * `getByIDs` is what `Workflow.nodes` resolves through, so its ordering is the
+ * ordering every operation list in the UI ends up rendering. Mongo's `$in` gives
+ * back natural (creation) order, which only coincides with the workflow's stored
+ * flow order until an edit inserts a node mid-chain.
+ */
+describe('WorkflowNodeService.getByIDs', () => {
+  const NODE_A = '00000000000000000000000a';
+  const NODE_B = '00000000000000000000000b';
+  const NODE_C = '00000000000000000000000c';
+
+  /** Stands in for Mongo: answers `$in` in creation order, never the argument's. */
+  const serviceReturning = (creationOrder: string[]): WorkflowNodeService => {
+    const nodeModel = {
+      find: jest.fn(async ({ _id }: { _id: { $in: string[] } }) => {
+        const wanted = new Set(_id.$in.map(String));
+        return creationOrder.filter((id) => wanted.has(id)).map((id) => ({ _id: id }));
+      })
+    };
+
+    return new WorkflowNodeService(nodeModel as any, {} as any, {} as any, {} as any);
+  };
+
+  it('returns nodes in the order they were asked for, not the order Mongo stored them', async () => {
+    const service = serviceReturning([NODE_A, NODE_B, NODE_C]);
+
+    const result = await service.getByIDs([NODE_C, NODE_A, NODE_B]);
+
+    expect(result.map((node) => String(node._id))).toEqual([NODE_C, NODE_A, NODE_B]);
+  });
+
+  it('places a newly created node where the workflow puts it, not last', async () => {
+    // The reported bug: B is inserted between A and C by an edit, so it is the
+    // newest document, but the workflow lists it second.
+    const service = serviceReturning([NODE_A, NODE_C, NODE_B]);
+
+    const result = await service.getByIDs([NODE_A, NODE_B, NODE_C]);
+
+    expect(result.map((node) => String(node._id))).toEqual([NODE_A, NODE_B, NODE_C]);
+  });
+
+  it('drops ids with no matching document rather than leaving a hole', async () => {
+    const service = serviceReturning([NODE_A, NODE_C]);
+
+    const result = await service.getByIDs([NODE_A, NODE_B, NODE_C]);
+
+    expect(result.map((node) => String(node._id))).toEqual([NODE_A, NODE_C]);
+  });
+
+  it('returns nothing for an empty id list', async () => {
+    const service = serviceReturning([NODE_A, NODE_B]);
+
+    expect(await service.getByIDs([])).toEqual([]);
+  });
+});

--- a/src/workflow/services/node.service.ts
+++ b/src/workflow/services/node.service.ts
@@ -36,10 +36,25 @@ export class WorkflowNodeService {
   }
 
   /**
-   * Get all nodes whose ID is in the given list
+   * Get all nodes whose ID is in the given list, in the order they were asked for.
+   *
+   * `$in` does not preserve the order of its argument — Mongo returns documents in
+   * natural (creation) order. A workflow's `nodes` array holds the graph's flow
+   * order, established breadth-first at submit time, so returning natural order
+   * here silently re-sorts every operation list into the order nodes happened to
+   * be created. That is invisible on a fresh submission, where the two coincide,
+   * and shows up the moment an edit inserts a node into the middle of a chain.
+   *
+   * Ids with no matching document are dropped rather than left as holes.
    */
   async getByIDs(ids: string[]): Promise<WorkflowNode[]> {
-    return this.workflowNodeModel.find({ _id: { $in: ids } });
+    const nodes = await this.workflowNodeModel.find({ _id: { $in: ids } });
+
+    const byId = new Map(nodes.map((node) => [String(node._id), node]));
+    return ids.flatMap((id) => {
+      const node = byId.get(String(id));
+      return node ? [node] : [];
+    });
   }
 
   async updateState(node: WorkflowNode, newState: WorkflowNodeState): Promise<WorkflowNode | null> {
@@ -64,12 +79,7 @@ export class WorkflowNodeService {
    * node. Caller is expected to have already verified the node itself is in
    * IN_PROGRESS (UI hides the picker otherwise).
    */
-  async setUsedInventory(
-    node: WorkflowNode,
-    inventoryIds: string[],
-    reservationStart?: Date | null,
-    reservationEnd?: Date | null
-  ): Promise<WorkflowNode | null> {
+  async setUsedInventory(node: WorkflowNode, inventoryIds: string[], reservationStart?: Date | null, reservationEnd?: Date | null): Promise<WorkflowNode | null> {
     const oids = (inventoryIds || []).map((id) => new mongoose.Types.ObjectId(id));
     if (reservationStart && reservationEnd && new Date(reservationEnd).getTime() <= new Date(reservationStart).getTime()) {
       throw new BadRequestException('Reservation end must be after the start.');
@@ -98,9 +108,7 @@ export class WorkflowNodeService {
 
   /** All in-progress nodes that currently hold any inventory (for the availability board). */
   async getInProgressNodesHoldingInventory(): Promise<WorkflowNode[]> {
-    return this.workflowNodeModel
-      .find({ state: WorkflowNodeState.IN_PROGRESS, usedInventory: { $exists: true, $ne: [] } })
-      .exec();
+    return this.workflowNodeModel.find({ state: WorkflowNodeState.IN_PROGRESS, usedInventory: { $exists: true, $ne: [] } }).exec();
   }
 
   async updateAssignee(node: WorkflowNode, assigneeId: string | null, assigneeDisplayName: string | null): Promise<WorkflowNode | null> {

--- a/src/workflow/workflow.resolver.ts
+++ b/src/workflow/workflow.resolver.ts
@@ -1,4 +1,4 @@
-import { UseGuards, Inject, forwardRef } from '@nestjs/common';
+import { UseGuards, Inject, forwardRef, Logger } from '@nestjs/common';
 import { Resolver, Query, Mutation, Args, ResolveField, Parent, ID } from '@nestjs/graphql';
 import { Workflow, WorkflowState } from './models/workflow.model';
 import { WorkflowService } from './workflow.service';
@@ -16,6 +16,8 @@ import { JobService } from '../job/job.service';
 @Resolver(() => Workflow)
 @UseGuards(AuthRolesGuard)
 export class WorkflowResolver {
+  private readonly logger = new Logger(WorkflowResolver.name);
+
   constructor(
     private readonly workflowService: WorkflowService,
     private readonly nodeService: WorkflowNodeService,
@@ -55,9 +57,29 @@ export class WorkflowResolver {
     return this.nodeService.getByIDs(workflow.nodes.map((node) => node._id.toString()));
   }
 
+  /**
+   * Dangling edges are dropped rather than returned.
+   *
+   * `WorkflowEdge.source`/`target` are non-nullable and throw when the node is
+   * gone, which fails the *entire* enclosing query — a single bad edge makes the
+   * whole job unreadable, for staff as well as the owner. A save that leaves an
+   * edge behind is a bug to fix at the write end (see JobVersionService), but
+   * this read path should degrade to a missing connection, not to a dead job.
+   * Warned rather than silent: dropping one is still data loss worth seeing.
+   */
   @ResolveField()
   async edges(@Parent() workflow: Workflow): Promise<WorkflowEdge[]> {
-    return this.edgeService.getByIDs(workflow.edges.map((edge) => edge._id.toString()));
+    const edges = await this.edgeService.getByIDs(workflow.edges.map((edge) => edge._id.toString()));
+    if (!edges.length) return edges;
+
+    const referenced = [...new Set(edges.flatMap((edge) => [String(edge.source), String(edge.target)]))];
+    const present = new Set((await this.nodeService.getByIDs(referenced)).map((node) => String(node._id)));
+
+    const kept = edges.filter((edge) => present.has(String(edge.source)) && present.has(String(edge.target)));
+    if (kept.length !== edges.length) {
+      this.logger.warn(`Workflow ${String(workflow._id)}: dropped ${edges.length - kept.length} edge(s) referencing missing nodes`);
+    }
+    return kept;
   }
 
   @ResolveField(() => Job, { nullable: true, description: 'The parent job this workflow belongs to' })


### PR DESCRIPTION
# Description

Major Changes:
 - SOW Revamp: SOW flow is now webform based (for both staff and clients); PDFs are exclusively an optional export.
 - Job Editing: Staff can now edit jobs after submission using the workflow editor, make editing available to the customer, and track the edits and versions of the job

Minor Changes
 - Optional field on services that can be incremented to run an operation multiple times
 - Workflow editor defaults to Operations rather than Bundles
 - Parameter-specific pricings now have categories that match the Operation pricings

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
