### PR TITLE
fix: persist technician assignments from SOW to Lab Monitor

### DIFF
--- a/src/sow/dto/create-sow.input.ts
+++ b/src/sow/dto/create-sow.input.ts
@@ -19,8 +19,14 @@ export class SOWResourcesInput {
   @Field({ description: 'Project manager assigned to the project' })
   projectManager: string;
 
+  @Field({ description: 'Keycloak sub of the project manager', nullable: true })
+  projectManagerId?: string;
+
   @Field({ description: 'Project lead assigned to the project' })
   projectLead: string;
+
+  @Field({ description: 'Keycloak sub of the project lead', nullable: true })
+  projectLeadId?: string;
 }
 
 @InputType()

--- a/src/sow/dto/sow-inputs.input.ts
+++ b/src/sow/dto/sow-inputs.input.ts
@@ -56,8 +56,14 @@ export class SowInputsInput {
   @Field({ nullable: true, defaultValue: '' })
   projectManager?: string;
 
+  @Field({ nullable: true, description: 'Keycloak sub of the project manager' })
+  projectManagerId?: string;
+
   @Field({ nullable: true, defaultValue: '' })
   projectLead?: string;
+
+  @Field({ nullable: true, description: 'Keycloak sub of the project lead' })
+  projectLeadId?: string;
 
   @Field(() => [SowPeriodInput], { nullable: true, defaultValue: [] })
   periods?: SowPeriodInput[];

--- a/src/sow/dto/update-sow.input.ts
+++ b/src/sow/dto/update-sow.input.ts
@@ -19,8 +19,14 @@ export class UpdateSOWResourcesInput {
   @Field({ description: 'Project manager assigned to the project', nullable: true })
   projectManager?: string;
 
+  @Field({ description: 'Keycloak sub of the project manager', nullable: true })
+  projectManagerId?: string;
+
   @Field({ description: 'Project lead assigned to the project', nullable: true })
   projectLead?: string;
+
+  @Field({ description: 'Keycloak sub of the project lead', nullable: true })
+  projectLeadId?: string;
 }
 
 @InputType()

--- a/src/sow/sow-apply-document-billing.spec.ts
+++ b/src/sow/sow-apply-document-billing.spec.ts
@@ -34,7 +34,7 @@ function harness(services: Array<{ serviceId: string; name?: string; cost: numbe
     })
   };
 
-  const service = new SOWService(sowModel, {} as any, {} as any, {} as any);
+  const service = new SOWService(sowModel, {} as any, {} as any, {} as any, {} as any, {} as any);
   return { service, sowDoc };
 }
 

--- a/src/sow/sow-create-for-job.spec.ts
+++ b/src/sow/sow-create-for-job.spec.ts
@@ -31,7 +31,7 @@ function harness(opts: { existingSow?: unknown; job?: unknown; deliverablesById?
     findById: async () => (opts.job === undefined ? { _id: 'job1', name: 'Job', username: 'jdoe', email: 'j@bu.edu', institute: 'BU' } : opts.job)
   };
 
-  const service = new SOWService(sowModel, dampLabServices, jobService, {} as any);
+  const service = new SOWService(sowModel, dampLabServices, jobService, {} as any, {} as any, {} as any);
   // `create` is covered by its own tests; here we only care what it is handed.
   (service as any).create = async (input: CreateSOWInput): Promise<unknown> => {
     created.push(input);

--- a/src/sow/sow-number.spec.ts
+++ b/src/sow/sow-number.spec.ts
@@ -10,7 +10,7 @@ function serviceWith(sowNumbers: string[]): SOWService {
   const model: any = {
     find: () => ({ lean: () => ({ exec: async () => sowNumbers.map((sowNumber) => ({ sowNumber })) }) })
   };
-  return new SOWService(model, {} as any, {} as any, {} as any);
+  return new SOWService(model, {} as any, {} as any, {} as any, {} as any, {} as any);
 }
 
 describe('parseSowNumber', () => {

--- a/src/sow/sow-version.model.ts
+++ b/src/sow/sow-version.model.ts
@@ -165,9 +165,17 @@ export class SowVersionInputs {
   @Field({ defaultValue: '' })
   projectManager: string;
 
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Keycloak sub of the project manager' })
+  projectManagerId?: string;
+
   @Prop({ required: true, default: '' })
   @Field({ defaultValue: '' })
   projectLead: string;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Keycloak sub of the project lead' })
+  projectLeadId?: string;
 
   @Prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
   @Field(() => [SowPeriod])

--- a/src/sow/sow-version.service.ts
+++ b/src/sow/sow-version.service.ts
@@ -402,7 +402,9 @@ export class SowVersionService {
     const inputs: SowVersionInputs = {
       ...derived,
       projectManager: input.inputs.projectManager ?? '',
+      projectManagerId: input.inputs.projectManagerId ?? undefined,
       projectLead: input.inputs.projectLead ?? '',
+      projectLeadId: input.inputs.projectLeadId ?? undefined,
       periods: (input.inputs.periods ?? []).map((p) => ({ startDate: new Date(p.startDate), durationDays: p.durationDays, label: p.label })),
       sowTitle: input.inputs.sowTitle ?? '',
       scopeOfWork: input.inputs.scopeOfWork ?? [],
@@ -436,6 +438,10 @@ export class SowVersionService {
     });
 
     await this.sowModel.findByIdAndUpdate(sowId, { $set: { currentVersionNumber: versionNumber, documentStale: false, updatedAt: new Date() } }).exec();
+
+    // Auto-assign Project Lead to unassigned workflow nodes
+    const previousLeadId = current?.inputs?.projectLeadId;
+    await this.sowService.autoAssignProjectLead(fresh.jobId, input.inputs.projectLeadId, input.inputs.projectLead, previousLeadId);
 
     return created;
   }

--- a/src/sow/sow-version.transitions.spec.ts
+++ b/src/sow/sow-version.transitions.spec.ts
@@ -136,7 +136,8 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
 
   const sowService: any = {
     applyDocumentBilling: async () => sow,
-    getJobForSow: async () => ({ customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC', jobId: '04217', sub: 'sub-owner', email: 'client@lab.org' })
+    getJobForSow: async () => ({ customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC', jobId: '04217', sub: 'sub-owner', email: 'client@lab.org' }),
+    autoAssignProjectLead: async () => undefined
   };
 
   return { service: new SowVersionService(versionModel, sowModel, sowService), sow, versions };

--- a/src/sow/sow.model.ts
+++ b/src/sow/sow.model.ts
@@ -71,9 +71,17 @@ export class SOWResources {
   @Field({ description: 'Project manager assigned to the project' })
   projectManager: string;
 
+  @Prop({ required: false })
+  @Field({ description: 'Keycloak sub of the project manager', nullable: true })
+  projectManagerId?: string;
+
   @Prop({ required: true })
   @Field({ description: 'Project lead assigned to the project' })
   projectLead: string;
+
+  @Prop({ required: false })
+  @Field({ description: 'Keycloak sub of the project lead', nullable: true })
+  projectLeadId?: string;
 }
 
 @Schema()

--- a/src/sow/sow.module.ts
+++ b/src/sow/sow.module.ts
@@ -7,6 +7,7 @@ import { SowVersionService } from './sow-version.service';
 import { SOWResolver } from './sow.resolver';
 import { SowVersionFieldsResolver } from './sow-version-fields.resolver';
 import { JobModule } from '../job/job.module';
+import { WorkflowModule } from '../workflow/workflow.module';
 import { DampLabServicesModule } from '../services/damplab-services.module';
 
 @Module({
@@ -16,6 +17,7 @@ import { DampLabServicesModule } from '../services/damplab-services.module';
       { name: SowVersion.name, schema: SowVersionSchema }
     ]),
     forwardRef(() => JobModule),
+    forwardRef(() => WorkflowModule),
     DampLabServicesModule
   ],
   providers: [SOWService, SowVersionService, SOWResolver, SowVersionFieldsResolver],

--- a/src/sow/sow.service.ts
+++ b/src/sow/sow.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException, NotFoundException, Inject, forwardRef } from '@nestjs/common';
+import { Injectable, BadRequestException, NotFoundException, Inject, forwardRef, Logger } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { SOW, SOWDocument, SOWStatus, SOWSignature, SOWSignatureRole } from './sow.model';
@@ -12,9 +12,13 @@ import { Role } from '../auth/roles/roles.enum';
 import { DampLabServices } from '../services/damplab-services.services';
 import { calculateServiceCost, extractRunCount, CustomerCategory } from '../pricing/service-pricing.util';
 import { SowVersionService } from './sow-version.service';
+import { WorkflowService } from '../workflow/workflow.service';
+import { WorkflowNodeService } from '../workflow/services/node.service';
 
 @Injectable()
 export class SOWService {
+  private readonly logger = new Logger(SOWService.name);
+
   constructor(
     @InjectModel(SOW.name) private readonly sowModel: Model<SOWDocument>,
     private readonly dampLabServices: DampLabServices,
@@ -23,7 +27,11 @@ export class SOWService {
     // Circular by design: SOWService creates version 1, and SowVersionService
     // writes billing changes back through SOWService. Both sides need forwardRef.
     @Inject(forwardRef(() => SowVersionService))
-    private readonly sowVersionService: SowVersionService
+    private readonly sowVersionService: SowVersionService,
+    @Inject(forwardRef(() => WorkflowService))
+    private readonly workflowService: WorkflowService,
+    @Inject(forwardRef(() => WorkflowNodeService))
+    private readonly workflowNodeService: WorkflowNodeService
   ) {}
 
   /**
@@ -627,7 +635,9 @@ export class SOWService {
    */
   async upsertForJob(jobId: string, createSOWInput: CreateSOWInput): Promise<SOW> {
     const existingSOW = await this.findByJobId(jobId);
+    const previousLeadId = existingSOW?.resources?.projectLeadId;
 
+    let result: SOW;
     if (existingSOW) {
       // Update existing SOW (do not pass sowNumber — it stays server-assigned)
       const updateInput: UpdateSOWInput = {
@@ -647,10 +657,48 @@ export class SOWService {
         additionalInformation: createSOWInput.additionalInformation,
         status: createSOWInput.status
       };
-      return this.update(existingSOW._id, updateInput);
+      result = await this.update(existingSOW._id, updateInput);
     } else {
       // Create new SOW
-      return this.create(createSOWInput);
+      result = await this.create(createSOWInput);
+    }
+
+    // Auto-assign the Project Lead to unassigned workflow nodes
+    await this.autoAssignProjectLead(jobId, createSOWInput.resources?.projectLeadId, createSOWInput.resources?.projectLead, previousLeadId);
+
+    return result;
+  }
+
+  /**
+   * Auto-assign the Project Lead to workflow nodes on a job.
+   * Only assigns nodes that have no assignee or that were assigned to the previous lead.
+   */
+  async autoAssignProjectLead(jobId: string, projectLeadId?: string, projectLeadName?: string, previousLeadId?: string): Promise<void> {
+    if (!projectLeadId || !projectLeadName) return;
+
+    try {
+      const job = await this.jobService.findById(jobId);
+      if (!job?.workflows?.length) return;
+
+      for (const workflowId of job.workflows) {
+        const workflow = await this.workflowService.findById(String(workflowId));
+        if (!workflow?.nodes?.length) continue;
+
+        const nodeIds = workflow.nodes.map((n: any) => String(n));
+        const nodes = await this.workflowNodeService.getByIDs(nodeIds);
+
+        for (const node of nodes) {
+          const currentAssignee = node.assigneeId;
+          // Assign if: no assignee, or previously assigned to the old lead
+          if (!currentAssignee || (previousLeadId && currentAssignee === previousLeadId)) {
+            await this.workflowNodeService.updateAssignee(node, projectLeadId, projectLeadName);
+          }
+        }
+      }
+
+      this.logger.log(`Auto-assigned Project Lead "${projectLeadName}" to unassigned nodes on job ${jobId}`);
+    } catch (err) {
+      this.logger.warn(`Failed to auto-assign Project Lead for job ${jobId}: ${err?.message ?? err}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix technician assignments made during SOW creation not appearing on the Lab Monitor. Previously, selecting a Project Manager and Project Lead in the SOW editor only stored their display names. The Lab Monitor reads assignments from workflow nodes (assigneeId + assigneeDisplayName), so there was no bridge between SOW resources and node assignments and staff had to manually reassign technicians on the Lab Monitor.

## Changes

- **SOW model** (`sow.model.ts`): Added `projectManagerId` and `projectLeadId` fields to `SOWResources`
- **SOW DTOs** (`create-sow.input.ts`, `update-sow.input.ts`, `sow-inputs.input.ts`): Added optional ID fields to all SOW resource input types
- **SOW version model** (`sow-version.model.ts`): Added ID fields to `SowVersionInputs` so they are persisted with each version
- **SOW module** (`sow.module.ts`): Imported `WorkflowModule` (with `forwardRef`) for access to node services
- **SOW service** (`sow.service.ts`): Injected `WorkflowService` + `WorkflowNodeService`; added `autoAssignProjectLead()` method that assigns the project lead to all unassigned workflow nodes when a SOW is saved
- **SOW version service** (`sow-version.service.ts`): Pass IDs through in `saveVersion()`; trigger auto-assignment after saving a version
- **Test files**: Updated `SOWService` constructor calls to match new dependencies

## How it works

1. When staff saves a SOW version with a Project Lead selected, `autoAssignProjectLead()` runs
2. It fetches the job's workflows and all their nodes
3. For each node with no assignee (or assigned to the previous lead), it calls `nodeService.updateAssignee()` with the lead's Keycloak ID and display name
4. The Lab Monitor immediately shows the assignment since it reads directly from node fields

## Safety

- All new fields are optional/nullable — no breaking changes to existing queries or data
- Existing SOWs without ID fields will not trigger auto-assignment (guarded by early return)
- Auto-assignment is wrapped in try/catch — failures are logged but don't block SOW saves
- Manual per-node assignments are preserved (only unassigned nodes are touched)