### PR TITLE
first pass fix of sow vs job pricing rework

### DIFF
--- a/src/invoice/invoice-billing-source.spec.ts
+++ b/src/invoice/invoice-billing-source.spec.ts
@@ -1,0 +1,117 @@
+import { InvoiceService } from './invoice.service';
+import { User } from '../auth/user.interface';
+
+/**
+ * What an invoice bills from.
+ *
+ * A SOW version is a static record; `sow.services` is not — the workflow sync
+ * overwrites it whenever the job spec changes. Invoicing from the billing core
+ * would therefore bill a figure no signed document ever stated, which is the
+ * exact failure the static-record rule exists to prevent. Invoices read the
+ * version in force with the customer.
+ */
+
+const staff = { realm_access: { roles: ['damplab-staff'] }, email: 'tech@bu.edu' } as unknown as User;
+
+interface HarnessOptions {
+  /** What the job currently prices these lines at — deliberately different from the document. */
+  liveServices?: any[];
+  livePricing?: any;
+  /** The version in force with the customer, or null for a legacy pre-versioning SOW. */
+  activeInputs?: any | null;
+}
+
+function harness(opts: HarnessOptions = {}): { service: InvoiceService; created: any[] } {
+  const created: any[] = [];
+
+  const invoiceModel: any = {
+    countDocuments: () => ({ exec: async (): Promise<number> => 0 }),
+    create: async (doc: any): Promise<any> => {
+      created.push(doc);
+      return doc;
+    }
+  };
+
+  const jobService: any = { findById: async () => ({ _id: 'job-1', jobId: '04217', name: 'Test job' }) };
+
+  const sowService: any = {
+    findByJobId: async () => ({
+      _id: 'sow-1',
+      services: opts.liveServices ?? [{ serviceId: 's1', name: 'PCR', cost: 420 }],
+      pricing: opts.livePricing ?? { baseCost: 420, adjustments: [{ type: 'DISCOUNT', description: 'Later discount', amount: 100 }], totalCost: 320 }
+    })
+  };
+
+  const sowVersionService: any = {
+    getActiveVersion: async () => (opts.activeInputs === null ? null : { inputs: opts.activeInputs ?? { services: [{ serviceId: 's1', name: 'PCR', cost: 350 }], adjustments: [] } })
+  };
+
+  return { service: new InvoiceService(invoiceModel, jobService, sowService, sowVersionService), created };
+}
+
+describe('invoice billing source', () => {
+  it('bills the signed figure, not the job’s current one', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob({ jobId: 'job-1', serviceIds: ['s1'] } as any, staff);
+
+    // The job now says $420; the version in force says $350.
+    expect(created[0].services[0].cost).toBe(350);
+    expect(created[0].subtotal).toBe(350);
+  });
+
+  it('does not apply an adjustment the customer never agreed to', async () => {
+    const { service, created } = harness();
+
+    await service.createForJob({ jobId: 'job-1', serviceIds: ['s1'] } as any, staff);
+
+    // sow.pricing carries a $100 discount added after the version was issued.
+    expect(created[0].adjustments).toEqual([]);
+    expect(created[0].totalCost).toBe(350);
+  });
+
+  it('applies the adjustments the version in force does carry', async () => {
+    const { service, created } = harness({
+      activeInputs: { services: [{ serviceId: 's1', name: 'PCR', cost: 350 }], adjustments: [{ type: 'DISCOUNT', description: 'Academic', amount: 50 }] }
+    });
+
+    await service.createForJob({ jobId: 'job-1', serviceIds: ['s1'] } as any, staff);
+
+    expect(created[0].adjustments[0]).toMatchObject({ type: 'DISCOUNT', appliedAmount: -50 });
+    expect(created[0].totalCost).toBe(300);
+  });
+
+  it('prorates against the version’s base, so a part-invoice takes its share of the discount', async () => {
+    const { service, created } = harness({
+      activeInputs: {
+        services: [
+          { serviceId: 's1', name: 'PCR', cost: 300 },
+          { serviceId: 's2', name: 'Gel', cost: 100 }
+        ],
+        adjustments: [{ type: 'DISCOUNT', description: 'Academic', amount: 40 }]
+      }
+    });
+
+    await service.createForJob({ jobId: 'job-1', serviceIds: ['s1'] } as any, staff);
+
+    // 300 of a 400 base = 0.75 of the $40 discount.
+    expect(created[0].adjustments[0].appliedAmount).toBe(-30);
+    expect(created[0].totalCost).toBe(270);
+  });
+
+  it('falls back to the billing core for a legacy SOW that has no version at all', async () => {
+    const { service, created } = harness({ activeInputs: null });
+
+    await service.createForJob({ jobId: 'job-1', serviceIds: ['s1'] } as any, staff);
+
+    expect(created[0].services[0].cost).toBe(420);
+    expect(created[0].adjustments[0]).toMatchObject({ type: 'DISCOUNT', appliedAmount: -100 });
+  });
+
+  it('refuses a non-staff caller', async () => {
+    const { service } = harness();
+    const customer = { realm_access: { roles: [] } } as unknown as User;
+
+    await expect(service.createForJob({ jobId: 'job-1', serviceIds: ['s1'] } as any, customer)).rejects.toThrow();
+  });
+});

--- a/src/invoice/invoice.service.ts
+++ b/src/invoice/invoice.service.ts
@@ -5,6 +5,7 @@ import { Invoice, InvoiceDocument } from './invoice.model';
 import { CreateInvoiceInput } from './dto/create-invoice.input';
 import { JobService } from '../job/job.service';
 import { SOWService } from '../sow/sow.service';
+import { SowVersionService } from '../sow/sow-version.service';
 import { User } from '../auth/user.interface';
 import { Role } from '../auth/roles/roles.enum';
 
@@ -19,7 +20,12 @@ function round2(n: number): number {
 
 @Injectable()
 export class InvoiceService {
-  constructor(@InjectModel(Invoice.name) private readonly invoiceModel: Model<InvoiceDocument>, private readonly jobService: JobService, private readonly sowService: SOWService) {}
+  constructor(
+    @InjectModel(Invoice.name) private readonly invoiceModel: Model<InvoiceDocument>,
+    private readonly jobService: JobService,
+    private readonly sowService: SOWService,
+    private readonly sowVersionService: SowVersionService
+  ) {}
 
   async findByJobId(jobId: string): Promise<Invoice[]> {
     return this.invoiceModel.find({ jobId }).sort({ createdAt: -1 }).exec();
@@ -47,7 +53,14 @@ export class InvoiceService {
       throw new BadRequestException('serviceIds must be a non-empty list');
     }
 
-    const sowServices = sow.services ?? [];
+    // Bill the version in force with the customer, not the job's current
+    // figures. `sow.services` tracks the job — the workflow sync overwrites it
+    // whenever the spec changes — so invoicing from it would bill a price no
+    // signed document ever stated. The active version is the thing the customer
+    // agreed to. A SOW with no active version at all (legacy, pre-versioning)
+    // falls back to the billing core, which is the only record it has.
+    const active = await this.sowVersionService.getActiveVersion(String((sow as any)._id));
+    const sowServices: any[] = active?.inputs?.services?.length ? active.inputs.services : sow.services ?? [];
     const serviceById = new Map(sowServices.map((s: any) => [String(s.serviceId ?? s._id ?? ''), s]));
 
     const selected = serviceIds.map((sid) => serviceById.get(String(sid))).filter(Boolean) as any[];
@@ -71,7 +84,9 @@ export class InvoiceService {
     const sowBaseCost = round2(sowServices.reduce((sum: number, s: any) => sum + (Number(s.cost) || 0), 0));
     const prorationFactor = sowBaseCost > 0 ? Math.min(1, subtotal / sowBaseCost) : 0;
 
-    const rawAdjustments = Array.isArray((sow as any).pricing?.adjustments) ? (sow as any).pricing.adjustments : [];
+    // Same rule as the service lines: the adjustments that were in force with
+    // the customer, not whatever the document holds today.
+    const rawAdjustments: any[] = active?.inputs?.adjustments ?? (Array.isArray((sow as any).pricing?.adjustments) ? (sow as any).pricing.adjustments : []);
     const adjustments = rawAdjustments.map((adj: any) => {
       const type = String(adj?.type ?? '');
       const amount = Number(adj?.amount) || 0;

--- a/src/job/job.model.ts
+++ b/src/job/job.model.ts
@@ -119,6 +119,28 @@ export class Job {
   @Field(() => JobState, { description: 'Where in the Job life cycle this Job is' })
   state: JobState;
 
+  /**
+   * The job's billing figures as they stood when staff accepted it — see
+   * SowVersionService.jobBillingFingerprint.
+   *
+   * A SOW may only be sent to the customer while this still matches the job's
+   * current figures. Editing the spec afterwards therefore re-locks the send
+   * until staff re-accept, which is what stops a price the customer never agreed
+   * to from reaching them. Absent on jobs accepted before this existed, which
+   * read as "never accepted" and need one re-accept to unlock.
+   */
+  @Prop({ required: false })
+  @Field({ description: 'Billing fingerprint of the job spec at the moment staff accepted it.', nullable: true })
+  acceptedBillingFingerprint?: string;
+
+  @Prop({ required: false })
+  @Field({ description: 'When staff last accepted this job as specified', nullable: true })
+  acceptedAt?: Date;
+
+  @Prop({ required: false })
+  @Field({ description: 'Keycloak sub of the staff member who last accepted this job', nullable: true })
+  acceptedBy?: string;
+
   @Prop({
     type: [
       {

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -49,41 +49,17 @@ export class JobResolver {
    * from the service record plus this data, and the run-count multiplier lives
    * inside it.
    */
-  private async collectSowServiceInputs(job: Job, existingServices: any[] = []): Promise<any[]> {
-    const orderedNodes: any[] = [];
-    for (const workflowId of job.workflows ?? []) {
-      const workflow = await this.workflowService.findById(String(workflowId));
-      if (!workflow) continue;
-
-      const nodeIds = (workflow.nodes ?? []).map((n: any) => String(n));
-      if (!nodeIds.length) continue;
-
-      const nodes = await this.workflowNodeService.getByIDs(nodeIds);
-      const byId = new Map(nodes.map((n: any) => [String(n._id), n]));
-
-      for (const nodeId of nodeIds) {
-        const node = byId.get(nodeId);
-        if (node) orderedNodes.push(node);
-      }
-    }
-
-    return orderedNodes.map((node: any, idx: number) => {
-      const existing = existingServices[idx];
-      const serviceId = String(node.service?._id ?? node.service);
-
-      return {
-        id: serviceId,
-        name: existing?.name ?? node.label ?? 'Service',
-        description: existing?.description ?? node.label ?? 'Service',
-        // A unit price, not a line total: transformServices multiplies whatever
-        // arrives here by the node's multiplier when the service record carries
-        // no price of its own.
-        unitCost: existing?.unitCost ?? node.price ?? 0,
-        cost: existing?.cost ?? node.price ?? 0,
-        category: existing?.category ?? 'molecular-biology',
-        formData: node.formData ?? []
-      };
-    });
+  /**
+   * Records the job's billing figures as of now, so a later spec change is
+   * detectable as "no longer the thing that was accepted".
+   *
+   * Read from the job's own workflows rather than from a SOW: acceptance
+   * routinely happens before a SOW exists at all — that is the point of gating
+   * the send on it — so there is nothing on the document side to read yet.
+   */
+  private async stampAcceptance(job: Job, user: User): Promise<void> {
+    const fingerprint = await this.sowService.jobBillingFingerprint(job);
+    await this.jobService.recordAcceptance(String((job as any)._id), fingerprint, user.sub);
   }
 
   private async syncSowServicesFromJobWorkflows(jobId: string): Promise<void> {
@@ -93,7 +69,7 @@ export class JobResolver {
     const existingSow = await this.sowService.findByJobId(jobId);
     if (!existingSow) return;
 
-    const servicesInput = await this.collectSowServiceInputs(job, existingSow.services ?? []);
+    const servicesInput = await this.sowService.collectSowServiceInputs(job, existingSow.services ?? []);
     if (servicesInput.length === 0) return;
 
     const updateInput: UpdateSOWInput = { services: servicesInput } as any;
@@ -326,25 +302,21 @@ export class JobResolver {
     return updated;
   }
 
+  /**
+   * Staff-only. The customer used to be permitted here on the grounds that it is
+   * "their" category, but the blast radius is not job-local: it rewrites their
+   * Keycloak pricing group, every job under the account, and every SOW billing
+   * core — i.e. a customer could reprice their own work.
+   */
   @Mutation(() => Job, {
     description:
-      'Change pricing category for a job owner: updates their Keycloak pricing group, every job under that account, and reprices SOW billing cores (documents stay stale until staff refresh).'
+      'Staff-only. Change pricing category for a job owner: updates their Keycloak pricing group, every job under that account, and reprices SOW billing cores (documents stay stale until staff refresh).'
   })
-  async changeJobCustomerCategory(
-    @Args('jobId', { type: () => ID }) jobId: string,
-    @Args('customerCategory', { type: () => CustomerCategory }) customerCategory: CustomerCategory,
-    @CurrentUser() user: User
-  ): Promise<Job> {
+  @Roles(Role.DamplabStaff)
+  async changeJobCustomerCategory(@Args('jobId', { type: () => ID }) jobId: string, @Args('customerCategory', { type: () => CustomerCategory }) customerCategory: CustomerCategory): Promise<Job> {
     const job = await this.jobService.findById(jobId);
     if (!job) {
       throw new NotFoundException(`Job with ID ${jobId} not found`);
-    }
-
-    const roles = user.realm_access?.roles ?? [];
-    const isStaff = roles.includes(Role.DamplabStaff);
-    const isOwner = job.sub === user.sub;
-    if (!isStaff && !isOwner) {
-      throw new ForbiddenException('You do not have permission to change customer category for this job');
     }
 
     // Account-wide: Keycloak group first (staff path / when Admin API is available), then all jobs for this sub.
@@ -385,7 +357,7 @@ export class JobResolver {
       throw new NotFoundException(`Job with ID ${jobId} not found`);
     }
 
-    const services = await this.collectSowServiceInputs(job);
+    const services = await this.sowService.collectSowServiceInputs(job);
     const createdBy = user.email || user.preferred_username || 'unknown';
 
     return this.sowService.createForJob(jobId, services, createdBy);
@@ -478,13 +450,26 @@ export class JobResolver {
     }
 
     const wasResubmission = job.state === JobState.CHANGES_REQUESTED && newState === JobState.SUBMITTED;
+    // Re-accepting a job that is already ACCEPTED re-stamps the fingerprint to
+    // release a locked send. It is not a transition, so it gets no history row:
+    // the customer's version list would otherwise fill with repeated "Accepted"
+    // entries during a negotiation. The re-stamp is still audited on the job
+    // itself via acceptedAt / acceptedBy.
+    const isReAcceptance = job.state === JobState.ACCEPTED && newState === JobState.ACCEPTED;
     const updated = (await this.jobService.updateState(job, newState))!;
+
+    // Accepting stamps the spec the lab agreed to. Re-accepting an already
+    // ACCEPTED job re-stamps it, which is how staff release a send that a later
+    // job edit re-locked — see SowVersionService.actionGate.
+    if (newState === JobState.ACCEPTED) {
+      await this.stampAcceptance(updated, user);
+    }
 
     // Recorded after the state actually moved, so a failed transition leaves no
     // entry. A resubmission is called out by name: "Submitted" on the second
     // pass would read as a duplicate of the original submission.
     const note = wasResubmission ? 'Resubmitted' : JobResolver.STATE_EVENT_NOTES[newState];
-    if (note) {
+    if (note && !isReAcceptance) {
       await this.jobVersionService.appendStateEvent(updated, newState, { role: this.authorRoleFor(user), sub: user.sub, name: user.preferred_username ?? user.email ?? '' }, note);
     }
 

--- a/src/job/job.service.ts
+++ b/src/job/job.service.ts
@@ -121,6 +121,14 @@ export class JobService {
     return this.jobModel.findOneAndUpdate({ _id: job._id }, { $set: { state: newState } }, { new: true }).exec();
   }
 
+  /**
+   * Records the spec staff just accepted. Re-accepting overwrites, which is how
+   * a send re-locked by a later job edit gets released.
+   */
+  async recordAcceptance(jobId: string, fingerprint: string, acceptedBy?: string): Promise<Job | null> {
+    return this.jobModel.findOneAndUpdate({ _id: jobId }, { $set: { acceptedBillingFingerprint: fingerprint, acceptedAt: new Date(), acceptedBy: acceptedBy ?? null } }, { new: true }).exec();
+  }
+
   async updateCustomerCategory(jobId: string, customerCategory: CustomerCategory): Promise<Job | null> {
     return this.jobModel.findOneAndUpdate({ _id: jobId }, { $set: { customerCategory } }, { new: true }).exec();
   }

--- a/src/sow/dto/save-sow-version.input.ts
+++ b/src/sow/dto/save-sow-version.input.ts
@@ -41,4 +41,12 @@ export class SaveSowVersionInput {
    */
   @Field({ description: 'Note describing what changed, shown in the version history. Required.' })
   note: string;
+
+  @Field({
+    nullable: true,
+    defaultValue: false,
+    description:
+      "True when staff clicked Recalculate on the Fee Schedule. The document's figures are a static record and carry forward untouched otherwise; this is an intent flag, never a price — the server derives the figures itself."
+  })
+  refreshFeeSchedule?: boolean;
 }

--- a/src/sow/dto/sow-inputs.input.ts
+++ b/src/sow/dto/sow-inputs.input.ts
@@ -30,12 +30,12 @@ export class SowVersionServiceInput {
   @Field({ nullable: true, defaultValue: '' })
   description?: string;
 
-  @Field(() => Float, { description: 'What this line bills. Ignored when unitCost is sent — the total is derived there. Kept for callers written before unit prices existed.' })
+  @Field(() => Float, { description: 'Deprecated and ignored. Service line figures come from the job spec; the document cannot set them.' })
   cost: number;
 
   @Field(() => Float, {
     nullable: true,
-    description: 'Price of a single run. A staff override here writes through to the billing core invoices read; the line total becomes unitCost x the multiplier the workflow baked in.'
+    description: 'Deprecated and ignored. Retained so an older browser bundle does not fail validation; service prices are owned by the job spec.'
   })
   unitCost?: number;
 }
@@ -97,4 +97,7 @@ export class SowInputsInput {
 
   @Field(() => [SowVersionAdjustmentInput], { nullable: true, defaultValue: [] })
   adjustments?: SowVersionAdjustmentInput[];
+
+  @Field({ nullable: true, defaultValue: false, description: 'Preview the refreshed Fee Schedule figures rather than the ones carried forward from the current version.' })
+  refreshFeeSchedule?: boolean;
 }

--- a/src/sow/dto/update-sow.input.ts
+++ b/src/sow/dto/update-sow.input.ts
@@ -1,6 +1,5 @@
 import { InputType, Field, Float } from '@nestjs/graphql';
 import { SOWServiceInput, SOWPricingAdjustmentInput, SOWDiscountInput } from './create-sow.input';
-import { SOWStatus } from '../sow.model';
 
 @InputType()
 export class UpdateSOWTimelineInput {
@@ -98,6 +97,8 @@ export class UpdateSOWInput {
   @Field({ description: 'Additional information', nullable: true })
   additionalInformation?: string;
 
-  @Field(() => SOWStatus, { description: 'Status of the SOW', nullable: true })
-  status?: SOWStatus;
+  // `status` is deliberately absent. It used to be writable here with no
+  // transition guard, which let a caller set SENT or SIGNED directly and walk
+  // straight past sendToCustomer's checks. The version state machine
+  // (SowVersionService) owns status now; nothing else may set it.
 }

--- a/src/sow/sow-apply-document-billing.spec.ts
+++ b/src/sow/sow-apply-document-billing.spec.ts
@@ -1,15 +1,14 @@
 import { SOWService } from './sow.service';
 
 /**
- * Writing the Fee Schedule's edited costs back to the billing core.
+ * Writing a document's adjustment edits back to the billing core.
  *
- * The bug this guards against: a job can use the same catalogue service more
- * than once (two PCR steps at different run counts, say). Costs used to be
- * matched by serviceId, so saving collapsed every line sharing that id onto
- * whichever cost came last in the request — a 70-run line silently became a
- * 1-run line's price. See sow-version.service.spec.ts / servicePricing.ts for
- * where the run-count multiplier itself is computed; this only covers whether
- * an already-computed cost lands on the right line when saved.
+ * Service lines are deliberately absent from this path. Their figures come from
+ * the job spec — what the customer proposed and the lab accepted — and are
+ * refreshed by the workflow sync (see job.resolver's collectSowServiceInputs).
+ * The document alters what it bills by adding a DISCOUNT or ADDITIONAL_COST,
+ * which the customer sees as its own line with its own reason, never by
+ * rewriting a price they already agreed to.
  */
 
 interface Harness {
@@ -27,7 +26,9 @@ function harness(services: Array<{ serviceId: string; name?: string; cost: numbe
     findById: () => ({ exec: async () => sowDoc }),
     findByIdAndUpdate: (_id: string, update: any): { exec: () => Promise<any> } => ({
       exec: async (): Promise<any> => {
-        sowDoc.services = update.$set.services;
+        // Mirrors the real update: only `pricing` is in the $set. If a future
+        // change starts writing `services` here, these tests fail loudly.
+        if (update.$set.services !== undefined) sowDoc.services = update.$set.services;
         sowDoc.pricing = update.$set.pricing;
         return sowDoc;
       }
@@ -39,134 +40,83 @@ function harness(services: Array<{ serviceId: string; name?: string; cost: numbe
 }
 
 describe('applyDocumentBilling', () => {
-  it('keeps each line at its own cost when the same service appears twice', async () => {
-    const { service, sowDoc } = harness([
-      { serviceId: 'pcr', cost: 350 }, // 70 runs
-      { serviceId: 'pcr', cost: 5 } // 1 run
-    ]);
+  describe('service lines are owned by the job, not the document', () => {
+    it('leaves every service line untouched', async () => {
+      const { service, sowDoc } = harness([
+        { serviceId: 'pcr', cost: 350, unitCost: 5, multiplier: 70 },
+        { serviceId: 'gel', cost: 20, unitCost: 20, multiplier: 1 }
+      ]);
 
-    await service.applyDocumentBilling('sow-1', {
-      serviceCosts: [
+      await service.applyDocumentBilling('sow-1', {
+        adjustments: [{ type: 'ADDITIONAL_COST', description: 'Rush', amount: 100 }] as any
+      });
+
+      expect(sowDoc.services[0]).toMatchObject({ cost: 350, unitCost: 5, multiplier: 70 });
+      expect(sowDoc.services[1]).toMatchObject({ cost: 20, unitCost: 20, multiplier: 1 });
+    });
+
+    it('never puts services in the update, so a sync cannot be clobbered mid-edit', async () => {
+      const sowDoc: any = { services: [{ serviceId: 'pcr', name: 'PCR', description: '', cost: 350 }], pricing: { adjustments: [] } };
+      let seen: any = null;
+      const sowModel: any = {
+        findById: () => ({ exec: async () => sowDoc }),
+        findByIdAndUpdate: (_id: string, update: any): { exec: () => Promise<any> } => ({
+          exec: async (): Promise<any> => {
+            seen = update.$set;
+            return sowDoc;
+          }
+        })
+      };
+      const service = new SOWService(sowModel, {} as any, {} as any, {} as any, {} as any, {} as any);
+
+      await service.applyDocumentBilling('sow-1', { adjustments: [] as any });
+
+      expect(seen).not.toBeNull();
+      expect(seen.services).toBeUndefined();
+    });
+
+    it('still derives baseCost from the stored service lines', async () => {
+      const { service, sowDoc } = harness([
         { serviceId: 'pcr', cost: 350 },
-        { serviceId: 'pcr', cost: 5 }
-      ]
+        { serviceId: 'gel', cost: 20 }
+      ]);
+
+      await service.applyDocumentBilling('sow-1', { adjustments: [] as any });
+
+      expect(sowDoc.pricing.baseCost).toBe(370);
+      expect(sowDoc.pricing.totalCost).toBe(370);
     });
 
-    expect(sowDoc.services[0].cost).toBe(350);
-    expect(sowDoc.services[1].cost).toBe(5);
-  });
+    it('keeps each line at its own cost when the same service appears twice', async () => {
+      const { service, sowDoc } = harness([
+        { serviceId: 'pcr', cost: 350 }, // 70 runs
+        { serviceId: 'pcr', cost: 5 } // 1 run
+      ]);
 
-  it('applies an edited cost to the line it was edited on', async () => {
-    const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 100 }]);
+      await service.applyDocumentBilling('sow-1', { adjustments: [] as any });
 
-    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', cost: 275 }] });
-
-    expect(sowDoc.services[0].cost).toBe(275);
-  });
-
-  it('leaves every line unchanged if the request has a different number of lines than the SOW', async () => {
-    const { service, sowDoc } = harness([
-      { serviceId: 'pcr', cost: 350 },
-      { serviceId: 'gel', cost: 20 }
-    ]);
-
-    // Simulates a workflow sync having changed the SOW's lines while the
-    // editor was still open with its old, now-shorter set.
-    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', cost: 999 }] });
-
-    expect(sowDoc.services[0].cost).toBe(350);
-    expect(sowDoc.services[1].cost).toBe(20);
-  });
-
-  it('leaves a line unchanged if its position no longer matches the serviceId it was saved for', async () => {
-    const { service, sowDoc } = harness([
-      { serviceId: 'pcr', cost: 350 },
-      { serviceId: 'gel', cost: 20 }
-    ]);
-
-    // Same length, but the order the client remembers no longer lines up —
-    // must not silently apply "gel"'s edit onto the "pcr" line.
-    await service.applyDocumentBilling('sow-1', {
-      serviceCosts: [
-        { serviceId: 'gel', cost: 999 },
-        { serviceId: 'pcr', cost: 888 }
-      ]
+      expect(sowDoc.services[0].cost).toBe(350);
+      expect(sowDoc.services[1].cost).toBe(5);
+      expect(sowDoc.pricing.baseCost).toBe(355);
     });
-
-    expect(sowDoc.services[0].cost).toBe(350);
-    expect(sowDoc.services[1].cost).toBe(20);
   });
 
-  it('recomputes baseCost and totalCost from the applied costs', async () => {
-    const { service } = harness([
-      { serviceId: 'pcr', cost: 350 },
-      { serviceId: 'pcr', cost: 5 }
-    ]);
-
-    const updated = await service.applyDocumentBilling('sow-1', {
-      serviceCosts: [
-        { serviceId: 'pcr', cost: 350 },
-        { serviceId: 'pcr', cost: 5 }
-      ]
-    });
-
-    expect(updated.pricing.baseCost).toBe(355);
-    expect(updated.pricing.totalCost).toBe(355);
-  });
-
-  /**
-   * The Fee Schedule box holds the base price, not the line total, so the
-   * multiplier the workflow baked in has to be re-applied here — the document
-   * has no control that could have changed it.
-   */
-  it('derives the line total from an edited unit price and the stored multiplier', async () => {
-    const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 350, unitCost: 5, multiplier: 70 }]);
-
-    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', unitCost: 6, cost: 350 }] });
-
-    expect(sowDoc.services[0].unitCost).toBe(6);
-    expect(sowDoc.services[0].cost).toBe(420);
-  });
-
-  it('keeps the total to the cent when the unit price does not divide evenly', async () => {
-    const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 9.9, unitCost: 3.3, multiplier: 3 }]);
-
-    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', unitCost: 3.3, cost: 9.9 }] });
-
-    expect(sowDoc.services[0].cost).toBe(9.9);
-  });
-
-  it('treats a line with no multiplier as multiplying by one', async () => {
-    const { service, sowDoc } = harness([{ serviceId: 'gel', cost: 20 }]);
-
-    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'gel', unitCost: 25, cost: 20 }] });
-
-    expect(sowDoc.services[0].cost).toBe(25);
-  });
-
-  it('does not read an explicit null unit price as a free line', async () => {
-    const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 350 }]);
-
-    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', unitCost: null as any, cost: 275 }] });
-
-    expect(sowDoc.services[0].cost).toBe(275);
-  });
-
-  it('still writes a bare cost through for a caller that sends no unit price', async () => {
-    const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 350, unitCost: 5, multiplier: 70 }]);
-
-    await service.applyDocumentBilling('sow-1', { serviceCosts: [{ serviceId: 'pcr', cost: 275 }] });
-
-    expect(sowDoc.services[0].cost).toBe(275);
-    expect(sowDoc.services[0].unitCost).toBe(5);
-  });
-
-  /**
-   * Adjustments follow the same rule as service lines: the client's `amount` is
-   * never trusted where it can be derived, because that figure is what invoices
-   * bill from (invoice.service.ts prorates it) long after the document is saved.
-   */
   describe('adjustments', () => {
+    it('leaves the stored adjustments alone when none are sent', async () => {
+      const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 350 }]);
+      sowDoc.pricing.adjustments = [{ type: 'ADDITIONAL_COST', description: 'Kept', amount: 50 }];
+
+      await service.applyDocumentBilling('sow-1', {});
+
+      expect(sowDoc.pricing.adjustments).toEqual([{ type: 'ADDITIONAL_COST', description: 'Kept', amount: 50 }]);
+      expect(sowDoc.pricing.totalCost).toBe(400);
+    });
+
+    /**
+     * The client's `amount` is never trusted where it can be derived, because
+     * that figure is what invoices bill from (invoice.service.ts prorates it)
+     * long after the document is saved.
+     */
     it('derives the figure from the unit amount and multiplier, ignoring the amount sent with them', async () => {
       const { service, sowDoc } = harness([{ serviceId: 'pcr', cost: 350 }]);
 

--- a/src/sow/sow-version.service.spec.ts
+++ b/src/sow/sow-version.service.spec.ts
@@ -217,3 +217,107 @@ describe('previewCalculatedValues — prose blocks', () => {
     expect(valueFor(rows, 'feeSchedule')).toContain('$350.00');
   });
 });
+
+/**
+ * The job-owned half of the billing core — what the accept-before-send gate
+ * compares. Adjustments are excluded on purpose: staff author those on the
+ * document and must be able to change them without re-opening the customer's
+ * agreement to the spec.
+ */
+describe('jobBillingFingerprint', () => {
+  const services = [{ serviceId: 's1', name: 'PCR', cost: 350, unitCost: 5, multiplier: 70 }];
+
+  it('is stable for the same services and category', () => {
+    expect(SowVersionService.jobBillingFingerprint(services, 'INTERNAL_CUSTOMERS')).toBe(SowVersionService.jobBillingFingerprint([{ ...services[0] }], 'INTERNAL_CUSTOMERS'));
+  });
+
+  it('moves when a unit price moves', () => {
+    expect(SowVersionService.jobBillingFingerprint([{ ...services[0], unitCost: 6, cost: 420 }], 'INTERNAL_CUSTOMERS')).not.toBe(
+      SowVersionService.jobBillingFingerprint(services, 'INTERNAL_CUSTOMERS')
+    );
+  });
+
+  it('moves when the multiplier moves, even though the line total is unchanged', () => {
+    expect(SowVersionService.jobBillingFingerprint([{ ...services[0], unitCost: 10, multiplier: 35 }], 'INTERNAL_CUSTOMERS')).not.toBe(
+      SowVersionService.jobBillingFingerprint(services, 'INTERNAL_CUSTOMERS')
+    );
+  });
+
+  it('moves when the pricing category moves', () => {
+    expect(SowVersionService.jobBillingFingerprint(services, 'EXTERNAL_CUSTOMER_MARKET')).not.toBe(SowVersionService.jobBillingFingerprint(services, 'INTERNAL_CUSTOMERS'));
+  });
+
+  it('computes for a job with no service lines at all — acceptance routinely precedes the SOW', () => {
+    expect(() => SowVersionService.jobBillingFingerprint(null, null)).not.toThrow();
+    expect(SowVersionService.jobBillingFingerprint(null, null)).toBe(SowVersionService.jobBillingFingerprint([], null));
+  });
+
+  it('is not tripped by an adjustment, which billingFingerprint does notice', () => {
+    const base = { services, adjustments: [], baseCost: 350, totalCost: 350, customerCategory: 'INTERNAL_CUSTOMERS' } as any;
+    const withAdjustment = { ...base, adjustments: [{ type: 'DISCOUNT', description: 'Academic', amount: 50 }], totalCost: 300 } as any;
+
+    expect(SowVersionService.jobBillingFingerprint(withAdjustment.services, withAdjustment.customerCategory)).toBe(SowVersionService.jobBillingFingerprint(base.services, base.customerCategory));
+    expect(SowVersionService.billingFingerprint(withAdjustment)).not.toBe(SowVersionService.billingFingerprint(base));
+  });
+});
+
+/**
+ * A SOW version is a static record. Its Fee Schedule figures carry forward
+ * untouched — a staff member editing prose must not silently reprice the
+ * document — and move only when staff explicitly refresh them.
+ */
+describe('feeScheduleInputs', () => {
+  const live: any = {
+    services: [{ serviceId: 's1', name: 'PCR', cost: 420, unitCost: 6, multiplier: 70 }],
+    adjustments: [],
+    customerCategory: 'EXTERNAL_CUSTOMER_MARKET'
+  };
+  const previous: any = {
+    services: [{ serviceId: 's1', name: 'PCR', cost: 350, unitCost: 5, multiplier: 70 }],
+    adjustments: [],
+    customerCategory: 'INTERNAL_CUSTOMERS'
+  };
+
+  it('carries the previous version forward when staff did not refresh', () => {
+    const out = SowVersionService.feeScheduleInputs(live, previous, false);
+
+    expect(out.services).toEqual(previous.services);
+    expect(out.customerCategory).toBe('INTERNAL_CUSTOMERS');
+    expect(out.baseCost).toBe(350);
+  });
+
+  it('takes the job figures when staff refreshed', () => {
+    const out = SowVersionService.feeScheduleInputs(live, previous, true);
+
+    expect(out.services).toEqual(live.services);
+    expect(out.customerCategory).toBe('EXTERNAL_CUSTOMER_MARKET');
+    expect(out.baseCost).toBe(420);
+  });
+
+  it('takes the job figures for a first version, which has nothing to carry', () => {
+    expect(SowVersionService.feeScheduleInputs(live, null, false).services).toEqual(live.services);
+  });
+
+  it('takes the job figures when the previous version has no lines — a migrated record, not a free job', () => {
+    expect(SowVersionService.feeScheduleInputs(live, { ...previous, services: [] }, false).services).toEqual(live.services);
+    expect(SowVersionService.feeScheduleInputs(live, { ...previous, services: undefined }, false).services).toEqual(live.services);
+  });
+
+  it('recomputes the total from the carried base and the document’s current adjustments', () => {
+    const withDiscount = { ...live, adjustments: [{ type: 'DISCOUNT', amount: 50 }] } as any;
+    const out = SowVersionService.feeScheduleInputs(withDiscount, previous, false);
+
+    // Base is the carried-forward 350, not the job's 420; the discount is current.
+    expect(out.baseCost).toBe(350);
+    expect(out.totalCost).toBe(300);
+  });
+
+  it('leaves the carried figures alone when only an adjustment changed', () => {
+    const before = SowVersionService.feeScheduleInputs(live, previous, false);
+    const after = SowVersionService.feeScheduleInputs({ ...live, adjustments: [{ type: 'ADDITIONAL_COST', amount: 25 }] } as any, previous, false);
+
+    expect(after.services).toEqual(before.services);
+    expect(after.baseCost).toBe(before.baseCost);
+    expect(after.totalCost).toBe(375);
+  });
+});

--- a/src/sow/sow-version.service.ts
+++ b/src/sow/sow-version.service.ts
@@ -2,14 +2,15 @@ import { Injectable, Logger, Inject, forwardRef, BadRequestException, ConflictEx
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import mongoose from 'mongoose';
-import { SOW, SOWDocument, SOWStatus, SOWAdjustmentType } from './sow.model';
-import { SowVersion, SowVersionDocument, SowVersionInputs, SowField, SowFieldKind, SowPeriod, SowConsent } from './sow-version.model';
+import { SOW, SOWDocument, SOWStatus, SOWAdjustmentType, DocumentBlocker, SowActionGate } from './sow.model';
+import { SowVersion, SowVersionDocument, SowVersionInputs, SowVersionService as SowVersionServiceLine, SowField, SowFieldKind, SowPeriod, SowConsent } from './sow-version.model';
 import { adjustmentAmount, adjustmentMultiplier, buildCalculatedFields, calculateFieldValues, normalizeIncomingFields, SowDocumentContext } from './sow-field-calculator';
 import { SOW_FIELD_CATALOG, findFieldDefinition } from './sow-field-defaults';
 import { SOWService } from './sow.service';
 import { SaveSowVersionInput } from './dto/save-sow-version.input';
 import { SignSowInput } from './dto/sign-sow.input';
 import { User } from '../auth/user.interface';
+import { JobState } from '../job/job.model';
 import { SowTextPresetService } from '../sow-preset/sow-text-preset.service';
 
 /**
@@ -20,6 +21,8 @@ import { SowTextPresetService } from '../sow-preset/sow-text-preset.service';
 export type SowInputsLike = Partial<Omit<SowVersionInputs, 'services' | 'periods'>> & {
   services?: Array<{ serviceId: string; name: string; description?: string; cost: number; unitCost?: number }>;
   periods?: Array<{ startDate: Date; durationDays: number; label?: string }>;
+  /** Mirrors SaveSowVersionInput: preview the refreshed figures rather than the carried-forward ones. */
+  refreshFeeSchedule?: boolean;
 };
 
 /**
@@ -116,6 +119,39 @@ export class SowVersionService {
     };
   }
 
+  /**
+   * The Fee Schedule half of a version's inputs: service lines, pricing category,
+   * and the totals that follow from them.
+   *
+   * A SOW version is a static record. Its figures therefore carry forward from
+   * the previous version unchanged — a staff member fixing a typo in the prose
+   * must not silently reprice the document — and move only when staff explicitly
+   * refresh the Fee Schedule, which is what `refresh` means here.
+   *
+   * `live` is job truth (deriveInputs off the current billing core). Note the
+   * client never names a figure either way: refreshing is a boolean intent, and
+   * the numbers always come from the server's own derivation.
+   */
+  static feeScheduleInputs(
+    live: SowVersionInputs,
+    previous: SowVersionInputs | null | undefined,
+    refresh: boolean
+  ): Pick<SowVersionInputs, 'services' | 'customerCategory' | 'baseCost' | 'totalCost'> {
+    // A previous version with no lines at all is a migrated or pre-versioning
+    // record, not a document that genuinely bills nothing. Carrying it forward
+    // would silently zero the fee schedule, so fall back to job truth.
+    const canCarry = previous != null && (previous.services ?? []).length > 0;
+    const source = refresh || !canCarry ? live : (previous as SowVersionInputs);
+    const services = source.services ?? [];
+    const baseCost = services.reduce((sum, svc) => sum + (Number(svc.cost) || 0), 0);
+
+    // Adjustments are document-owned and always current, so the total is the
+    // carried-forward base plus whatever the document says today.
+    const totalCost = (live.adjustments ?? []).reduce((sum, a) => sum + (a.type === SOWAdjustmentType.DISCOUNT ? -Math.abs(Number(a.amount) || 0) : Math.abs(Number(a.amount) || 0)), baseCost);
+
+    return { services, customerCategory: source.customerCategory, baseCost: Math.round(baseCost * 100) / 100, totalCost: Math.round(totalCost * 100) / 100 };
+  }
+
   static buildContext(sow: SOW, job?: { jobId?: string; name?: string } | null): SowDocumentContext {
     return {
       sowNumber: sow.sowNumber,
@@ -130,16 +166,32 @@ export class SowVersionService {
   }
 
   /**
+   * The half of the billing core the *job* owns: service lines and the pricing
+   * category. Adjustments and totals are deliberately excluded — those are
+   * staff-authored on the document, and staff are free to change them without
+   * re-opening the customer's agreement to the spec.
+   *
+   * This is what the accept-before-send gate compares: a job whose fingerprint
+   * still matches the one stamped at acceptance is a job the lab has agreed to
+   * as it currently stands.
+   */
+  static jobBillingFingerprint(services: Array<Pick<SowVersionServiceLine, 'serviceId' | 'name' | 'cost' | 'unitCost' | 'multiplier'>> | null | undefined, customerCategory?: string | null): string {
+    const lines = (services ?? []).map((s) => `${s.serviceId}:${s.name}:${Number(s.cost).toFixed(2)}:${s.unitCost == null ? '' : Number(s.unitCost).toFixed(2)}:${s.multiplier ?? ''}`).join('|');
+    return [lines, customerCategory ?? ''].join('#');
+  }
+
+  /**
    * What the Fee Schedule depends on. Two versions with the same fingerprint
    * would render the same figures, so a change here — and only here — means the
    * document has fallen behind the billing core.
+   *
+   * Delegates the job-owned half to jobBillingFingerprint so the two can never
+   * drift into disagreeing about what a service line's identity is.
    */
   static billingFingerprint(inputs: Pick<SowVersionInputs, 'services' | 'adjustments' | 'baseCost' | 'totalCost' | 'customerCategory'>): string {
-    const services = (inputs.services ?? [])
-      .map((s) => `${s.serviceId}:${s.name}:${Number(s.cost).toFixed(2)}:${s.unitCost == null ? '' : Number(s.unitCost).toFixed(2)}:${s.multiplier ?? ''}`)
-      .join('|');
+    const jobHalf = SowVersionService.jobBillingFingerprint(inputs.services, inputs.customerCategory);
     const adjustments = (inputs.adjustments ?? []).map((a) => `${a.type}:${a.description}:${Number(a.amount).toFixed(2)}`).join('|');
-    return [services, adjustments, Number(inputs.baseCost ?? 0).toFixed(2), Number(inputs.totalCost ?? 0).toFixed(2), inputs.customerCategory ?? ''].join('#');
+    return [jobHalf, adjustments, Number(inputs.baseCost ?? 0).toFixed(2), Number(inputs.totalCost ?? 0).toFixed(2)].join('#');
   }
 
   /**
@@ -337,6 +389,7 @@ export class SowVersionService {
     const sow = await this.requireSow(sowId);
     const job = await this.sowService.getJobForSow(sow);
     const stored = SowVersionService.deriveInputs(sow, job);
+    const currentVersion = await this.getCurrentVersion(String((sow as any)._id));
 
     const merged: SowVersionInputs = {
       ...stored,
@@ -346,29 +399,10 @@ export class SowVersionService {
       sowTitle: inputs.sowTitle ?? stored.sowTitle,
       scopeOfWork: inputs.scopeOfWork ?? stored.scopeOfWork,
       deliverables: inputs.deliverables ?? stored.deliverables,
-      // Unsaved billing edits still need to show in the preview, but only as
-      // costs applied to lines the SOW already has — a preview cannot invent one.
-      // Matched by position, not serviceId: the same catalogue service can appear
-      // on more than one line (different run counts), and a serviceId lookup
-      // would apply the first matching line's edit to every line sharing that id
-      // — see the identical reasoning on SOWService.applyDocumentBilling. Unlike
-      // that save path, there's no length gate here: a preview must keep showing
-      // whatever edits it safely can rather than dropping all of them the moment
-      // the arrays are transiently out of step (e.g. mid-render while inputs are
-      // still loading) — a line whose position no longer matches its own
-      // serviceId just falls through to the stored value, same as a genuine
-      // mismatch would.
-      services: (stored.services ?? []).map((s, i) => {
-        const edited = inputs.services?.[i];
-        if (!edited || String(edited.serviceId) !== String(s.serviceId)) return s;
-        // A unit-price edit has to carry the total with it, or the preview would
-        // quote a new base beside the stored line total it no longer produces.
-        if (edited.unitCost != null && Number.isFinite(edited.unitCost) && edited.unitCost >= 0) {
-          const multiplier = Number.isFinite(Number(s.multiplier)) && Number(s.multiplier) > 0 ? Number(s.multiplier) : 1;
-          return { ...s, unitCost: edited.unitCost, multiplier, cost: Math.round(edited.unitCost * multiplier * 100) / 100 };
-        }
-        return Number.isFinite(edited.cost) && edited.cost >= 0 ? { ...s, cost: edited.cost } : s;
-      }),
+      // The same choice the save path makes, so the preview quotes the figures a
+      // save would actually store: carried forward from the current version
+      // unless staff have hit Recalculate.
+      ...SowVersionService.feeScheduleInputs(stored, currentVersion?.inputs, inputs.refreshFeeSchedule === true),
       // Unsaved adjustment edits are previewed from the same derivation the save
       // path applies, so the preview quotes the figure the save would store
       // rather than whatever total the client happened to send with it.
@@ -430,13 +464,16 @@ export class SowVersionService {
     const note = input.note?.trim();
     if (!note) throw new BadRequestException('Describe what you changed before saving.');
 
-    // Billing figures first: the fee schedule text is generated from the billing
-    // core, so it has to be written before the document is composed or the saved
-    // text would describe the previous prices.
-    const hasBillingEdits = (input.inputs.services ?? []).length > 0 || input.inputs.adjustments !== undefined;
+    // Adjustments first: the fee schedule text is generated from the billing
+    // core, so they have to be written before the document is composed or the
+    // saved text would describe the previous totals.
+    //
+    // Service lines are not sent — they come from the job spec via the workflow
+    // sync, and `deriveInputs` below reads them back off the SOW. That is what
+    // makes a plain Save the way a document catches up with a changed job.
+    const hasBillingEdits = input.inputs.adjustments !== undefined;
     if (hasBillingEdits) {
       await this.sowService.applyDocumentBilling(sowId, {
-        serviceCosts: (input.inputs.services ?? []).map((s) => ({ serviceId: s.serviceId, unitCost: s.unitCost, cost: s.cost })),
         adjustments: (input.inputs.adjustments ?? []).map((a) => ({
           type: a.type,
           description: a.description,
@@ -456,8 +493,13 @@ export class SowVersionService {
     // the SOW after the write above, so the version records what was actually
     // stored rather than what the client claimed.
     const derived = SowVersionService.deriveInputs(fresh, job);
+    // Fee Schedule figures are a static record: they carry forward from the
+    // previous version unless staff explicitly refreshed them. See
+    // feeScheduleInputs for why this is a flag rather than figures on the wire.
+    const feeSchedule = SowVersionService.feeScheduleInputs(derived, current?.inputs, input.refreshFeeSchedule === true);
     const inputs: SowVersionInputs = {
       ...derived,
+      ...feeSchedule,
       projectManager: input.inputs.projectManager ?? '',
       projectManagerId: input.inputs.projectManagerId ?? undefined,
       projectLead: input.inputs.projectLead ?? '',
@@ -549,6 +591,92 @@ export class SowVersionService {
       .map((def) => def.label);
   }
 
+  /** One sentence naming the first thing standing in the way, and how to clear it. */
+  static blockerMessage(blockers: DocumentBlocker[], missingFields: string[] = []): string {
+    switch (blockers[0]) {
+      case DocumentBlocker.NOT_ACCEPTED:
+        return 'Accept this job before sending its Statement of Work — the customer needs to have agreed to the spec the prices come from.';
+      case DocumentBlocker.JOB_CHANGED_SINCE_ACCEPTANCE:
+        return 'This job changed after it was accepted. Re-accept it, then recalculate and save the document, before sending.';
+      case DocumentBlocker.DOCUMENT_STALE:
+        return "This document still bills the job's earlier figures. Recalculate the Fee Schedule and save before sending.";
+      case DocumentBlocker.DRAFT_INCOMPLETE:
+        return missingFields.length > 0 ? `Complete the following before sending to the customer: ${missingFields.join(', ')}.` : 'This SOW has no document to send.';
+      case DocumentBlocker.NO_DRAFT_TO_SEND:
+        return 'This version has already been issued. Edit the document to start a new draft before sending again.';
+      case DocumentBlocker.UNSENT_DRAFT:
+        return 'A newer draft sits above the version the customer signed. Send it and have them sign it before countersigning.';
+      case DocumentBlocker.AWAITING_CUSTOMER_SIGNATURE:
+        return 'The customer has not signed the version in force yet.';
+      default:
+        return 'This SOW cannot move to its next stage yet.';
+    }
+  }
+
+  /**
+   * Which lifecycle actions this SOW currently permits.
+   *
+   * One rule for the whole lifecycle: the job spec must be agreed (accepted, and
+   * unchanged since) and the document must match it. Signing is not a branch —
+   * a signed version is immutable, so a later job change simply runs the same
+   * rule again and the customer re-signs. Countersigning adds two conditions of
+   * its own, both of which say the same thing: you may only countersign the
+   * exact document the customer signed, and only while it is still current.
+   *
+   * DOCUMENT_STALE blocks both actions rather than warning, because
+   * appendVersion copies a version's fields verbatim: without it, staff could
+   * issue — or finalize — prose whose Fee Schedule contradicts the figures
+   * invoices bill from.
+   */
+  async actionGate(sowId: string): Promise<SowActionGate> {
+    const sow = await this.requireSow(sowId);
+    const current = await this.getCurrentVersion(sowId);
+    const active = await this.getActiveVersion(sowId);
+    const job = await this.sowService.getJobForSow(sow);
+
+    // Shared by both actions: the spec has to be agreed, and the document has to
+    // reflect it.
+    const specBlockers: DocumentBlocker[] = [];
+    const accepted = (job as any)?.acceptedBillingFingerprint;
+    if (!job || (job as any).state !== JobState.ACCEPTED || !accepted) {
+      specBlockers.push(DocumentBlocker.NOT_ACCEPTED);
+    } else if ((await this.sowService.jobBillingFingerprint(job as any)) !== accepted) {
+      specBlockers.push(DocumentBlocker.JOB_CHANGED_SINCE_ACCEPTANCE);
+    }
+    if (sow.documentStale) specBlockers.push(DocumentBlocker.DOCUMENT_STALE);
+
+    const missingFields = SowVersionService.missingRequiredFields(current?.fields ?? []);
+    const sendBlockers = [...specBlockers];
+    // Mutually exclusive, and in this order: no document at all, a document that
+    // has already gone out, then a draft with gaps in it. The second is what
+    // sendToCustomer's own `current.status !== DRAFT` check enforces — the gate
+    // has to agree with it or it would promise a send the server refuses.
+    if (!current) {
+      sendBlockers.push(DocumentBlocker.DRAFT_INCOMPLETE);
+    } else if (current.status !== SOWStatus.DRAFT) {
+      sendBlockers.push(DocumentBlocker.NO_DRAFT_TO_SEND);
+    } else if (missingFields.length > 0) {
+      sendBlockers.push(DocumentBlocker.DRAFT_INCOMPLETE);
+    }
+
+    const countersignBlockers = [...specBlockers];
+    if (!active || active.status !== SOWStatus.SIGNED) {
+      countersignBlockers.push(DocumentBlocker.AWAITING_CUSTOMER_SIGNATURE);
+    } else if (sow.currentVersionNumber > sow.activeVersionNumber) {
+      // Staff have revised the document since the customer signed. Countersigning
+      // now would finalize a version the lab has already moved on from.
+      countersignBlockers.push(DocumentBlocker.UNSENT_DRAFT);
+    }
+
+    return {
+      canSend: sendBlockers.length === 0,
+      sendBlockers,
+      canCountersign: countersignBlockers.length === 0,
+      countersignBlockers,
+      missingFields
+    };
+  }
+
   /** Issues the current draft to the customer. */
   async sendToCustomer(sowId: string, author: { sub: string; name: string }): Promise<SowVersionDocument> {
     const sow = await this.requireSow(sowId);
@@ -556,9 +684,11 @@ export class SowVersionService {
     if (!current) throw new BadRequestException('This SOW has no document to send.');
     if (current.status !== SOWStatus.DRAFT) throw new BadRequestException(`Only a draft can be sent; v${current.versionNumber} is ${current.status}.`);
 
-    const missing = SowVersionService.missingRequiredFields(current.fields ?? []);
-    if (missing.length > 0) {
-      throw new BadRequestException(`Complete the following before sending to the customer: ${missing.join(', ')}.`);
+    // The gate the UI shows, enforced here too: the resolved field is a
+    // convenience for disabling a button, never the thing that decides.
+    const gate = await this.actionGate(sowId);
+    if (!gate.canSend) {
+      throw new BadRequestException(SowVersionService.blockerMessage(gate.sendBlockers, gate.missingFields));
     }
 
     const now = new Date();
@@ -621,6 +751,16 @@ export class SowVersionService {
     if (!active) throw new BadRequestException('This SOW has nothing to finalize.');
     if (active.status !== SOWStatus.SIGNED) throw new BadRequestException(`Only a signed SOW can be finalized; v${active.versionNumber} is ${active.status}.`);
     if (!name?.trim()) throw new BadRequestException('A name is required to countersign.');
+
+    // A countersignature closes the agreement, so it may only land on the exact
+    // document the customer signed, and only while that document still matches
+    // the job. A stale figure or a draft sitting above the signed version both
+    // mean the lab has moved on from what was agreed — the revision has to go
+    // out and come back signed first.
+    const gate = await this.actionGate(sowId);
+    if (!gate.canCountersign) {
+      throw new BadRequestException(SowVersionService.blockerMessage(gate.countersignBlockers, gate.missingFields));
+    }
 
     const signature: SowConsent = {
       name: name.trim(),

--- a/src/sow/sow-version.transitions.spec.ts
+++ b/src/sow/sow-version.transitions.spec.ts
@@ -2,7 +2,8 @@ import { BadRequestException, ConflictException } from '@nestjs/common';
 import mongoose from 'mongoose';
 import { SowVersionService } from './sow-version.service';
 import { SowFieldKind } from './sow-version.model';
-import { SOWStatus } from './sow.model';
+import { SOWStatus, DocumentBlocker } from './sow.model';
+import { JobState } from '../job/job.model';
 import { User } from '../auth/user.interface';
 
 /**
@@ -36,7 +37,7 @@ function matches(doc: any, query: Record<string, any>): boolean {
   return Object.entries(query).every(([k, v]) => String(doc[k]) === String(v));
 }
 
-function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { service: SowVersionService; sow: any; versions: FakeVersion[] } {
+function makeHarness(initial: { status?: SOWStatus; fields?: any[]; job?: any; liveFingerprint?: string } = {}): { service: SowVersionService; sow: any; versions: FakeVersion[]; job: any } {
   const versions: FakeVersion[] = [
     {
       _id: 'v1',
@@ -134,9 +135,22 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
     })
   };
 
+  // Accepted, and unchanged since — the state a job has to be in for a send to
+  // be allowed at all. Tests that care about the gate override it.
+  const job: any = {
+    customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC',
+    jobId: '04217',
+    sub: 'sub-owner',
+    email: 'client@lab.org',
+    state: JobState.ACCEPTED,
+    acceptedBillingFingerprint: 'fp-accepted',
+    ...(initial.job ?? {})
+  };
+
   const sowService: any = {
     applyDocumentBilling: async () => sow,
-    getJobForSow: async () => ({ customerCategory: 'EXTERNAL_CUSTOMER_ACADEMIC', jobId: '04217', sub: 'sub-owner', email: 'client@lab.org' }),
+    getJobForSow: async () => job,
+    jobBillingFingerprint: async () => initial.liveFingerprint ?? 'fp-accepted',
     autoAssignProjectLead: async () => undefined
   };
 
@@ -144,7 +158,7 @@ function makeHarness(initial: { status?: SOWStatus; fields?: any[] } = {}): { se
   // transition tests assert against.
   const presetService: any = { defaultTextByKey: async () => ({}) };
 
-  return { service: new SowVersionService(versionModel, sowModel, sowService, presetService), sow, versions };
+  return { service: new SowVersionService(versionModel, sowModel, sowService, presetService), sow, versions, job };
 }
 
 const staff = { sub: 'sub-staff', name: 'tech' };
@@ -452,26 +466,290 @@ describe('discardDraft', () => {
 });
 
 describe('previewCalculatedValues', () => {
-  it('keeps each line at its own edited cost when the same service appears twice', async () => {
-    const { service, sow } = makeHarness();
-    sow.services = [
-      { serviceId: 'pcr', name: 'PCR', description: '', cost: 350 }, // 70 runs
-      { serviceId: 'pcr', name: 'PCR', description: '', cost: 5 } // 1 run
-    ];
+  /** A job can legitimately use the same catalogue service twice at different run counts. */
+  const twoPcrLines = [
+    { serviceId: 'pcr', name: 'PCR', description: '', cost: 350 }, // 70 runs
+    { serviceId: 'pcr', name: 'PCR', description: '', cost: 5 } // 1 run
+  ];
 
-    const preview = await service.previewCalculatedValues(SOW_ID, {
-      services: [
-        { serviceId: 'pcr', name: 'PCR', description: '', cost: 350 },
-        { serviceId: 'pcr', name: 'PCR', description: '', cost: 5 }
-      ]
-    } as any);
+  it("quotes the figures the document carries, not the job's current ones", async () => {
+    const { service, sow, versions } = makeHarness();
+    versions[0].inputs.services = twoPcrLines;
+    // The job has since been repriced; the preview must not show this.
+    sow.services = [{ serviceId: 'pcr', name: 'PCR', description: '', cost: 999 }];
 
+    const preview = await service.previewCalculatedValues(SOW_ID, {} as any);
     const feeSchedule = preview.find((f) => f.key === 'feeSchedule')?.calculatedValue ?? '';
-    // Both lines' costs must survive distinctly; a serviceId-keyed lookup would
-    // have applied the first line's edit ($350) to both, showing $700 total
-    // instead of $355 and losing the second line's true cost entirely.
+
+    // Both lines' costs survive distinctly; a serviceId-keyed lookup would have
+    // collapsed them onto one figure and lost the second line's true cost.
     expect(feeSchedule).toContain('$350.00');
     expect(feeSchedule).toContain('$5.00');
     expect(feeSchedule).toContain('Total: $355.00');
+    expect(feeSchedule).not.toContain('$999.00');
+  });
+
+  it('quotes the job figures once staff have hit Recalculate', async () => {
+    const { service, sow, versions } = makeHarness();
+    versions[0].inputs.services = twoPcrLines;
+    sow.services = [{ serviceId: 'pcr', name: 'PCR', description: '', cost: 999 }];
+
+    const preview = await service.previewCalculatedValues(SOW_ID, { refreshFeeSchedule: true } as any);
+    const feeSchedule = preview.find((f) => f.key === 'feeSchedule')?.calculatedValue ?? '';
+
+    expect(feeSchedule).toContain('$999.00');
+    expect(feeSchedule).toContain('Total: $999.00');
+  });
+
+  it('ignores service figures a client sends, whatever they are', async () => {
+    const { service, versions } = makeHarness();
+    versions[0].inputs.services = twoPcrLines;
+
+    const preview = await service.previewCalculatedValues(SOW_ID, {
+      services: [{ serviceId: 'pcr', name: 'PCR', description: '', cost: 1 }]
+    } as any);
+    const feeSchedule = preview.find((f) => f.key === 'feeSchedule')?.calculatedValue ?? '';
+
+    expect(feeSchedule).toContain('Total: $355.00');
+  });
+});
+
+/**
+ * The send gate.
+ *
+ * One rule for the whole lifecycle: the spec must be agreed (accepted, and
+ * unchanged since) and the document must match it. The signed-SOW block at the
+ * end runs the same table a second time and is the guard against a
+ * post-signature special case creeping back in.
+ */
+describe('actionGate — sending', () => {
+  it('allows a send when the job is accepted, unchanged, and the draft is complete', async () => {
+    const { service } = makeHarness();
+    const gate = await service.actionGate(SOW_ID);
+
+    expect(gate).toMatchObject({ canSend: true, sendBlockers: [] });
+  });
+
+  it('blocks a job that was never accepted', async () => {
+    const { service } = makeHarness({ job: { state: JobState.SUBMITTED, acceptedBillingFingerprint: undefined } });
+
+    expect((await service.actionGate(SOW_ID)).sendBlockers).toEqual([DocumentBlocker.NOT_ACCEPTED]);
+  });
+
+  it('blocks a job accepted before acceptance was recorded, so one re-accept unlocks it', async () => {
+    const { service } = makeHarness({ job: { state: JobState.ACCEPTED, acceptedBillingFingerprint: undefined } });
+
+    expect((await service.actionGate(SOW_ID)).sendBlockers).toEqual([DocumentBlocker.NOT_ACCEPTED]);
+  });
+
+  it('re-locks when the job spec moved after it was accepted', async () => {
+    const { service } = makeHarness({ liveFingerprint: 'fp-after-edit' });
+
+    expect((await service.actionGate(SOW_ID)).sendBlockers).toEqual([DocumentBlocker.JOB_CHANGED_SINCE_ACCEPTANCE]);
+  });
+
+  it('blocks a document whose figures lag the billing core', async () => {
+    const { service, sow } = makeHarness();
+    sow.documentStale = true;
+
+    expect((await service.actionGate(SOW_ID)).sendBlockers).toEqual([DocumentBlocker.DOCUMENT_STALE]);
+  });
+
+  it('blocks a draft missing a required section', async () => {
+    const { service } = makeHarness({
+      fields: [{ key: 'billToAddress', label: 'Bill To Address', kind: SowFieldKind.PROSE, order: 110, value: 'x', isOverridden: false, isEnabled: true, allowsTextOverride: true }]
+    });
+    const gate = await service.actionGate(SOW_ID);
+
+    expect(gate.sendBlockers).toEqual([DocumentBlocker.DRAFT_INCOMPLETE]);
+    expect(gate.missingFields).toContain('Engagement Resources');
+  });
+
+  it('reports blockers in the order staff should resolve them', async () => {
+    const { service, sow } = makeHarness({
+      job: { state: JobState.SUBMITTED, acceptedBillingFingerprint: undefined },
+      fields: [{ key: 'billToAddress', label: 'Bill To Address', kind: SowFieldKind.PROSE, order: 110, value: 'x', isOverridden: false, isEnabled: true, allowsTextOverride: true }]
+    });
+    sow.documentStale = true;
+
+    expect((await service.actionGate(SOW_ID)).sendBlockers).toEqual([DocumentBlocker.NOT_ACCEPTED, DocumentBlocker.DOCUMENT_STALE, DocumentBlocker.DRAFT_INCOMPLETE]);
+  });
+
+  it('is not re-locked by a staff adjustment, which is the whole point of adjustments surviving decision #2', async () => {
+    const { service, sow } = makeHarness();
+    // An adjustment moves the document's total but not the job's spec, so the
+    // acceptance still covers what the customer agreed to.
+    sow.pricing = { baseCost: 0, adjustments: [{ type: 'DISCOUNT', description: 'Academic', amount: 50 }], totalCost: -50 };
+
+    expect(await service.actionGate(SOW_ID)).toMatchObject({ canSend: true, sendBlockers: [] });
+  });
+
+  it('never reports both acceptance blockers at once — a job that was never accepted cannot also have drifted', async () => {
+    const { service } = makeHarness({ job: { state: JobState.SUBMITTED, acceptedBillingFingerprint: undefined }, liveFingerprint: 'fp-after-edit' });
+
+    expect((await service.actionGate(SOW_ID)).sendBlockers).toEqual([DocumentBlocker.NOT_ACCEPTED]);
+  });
+
+  describe('sendToCustomer enforces the gate rather than trusting the resolved field', () => {
+    it('refuses to send an unaccepted job', async () => {
+      const { service } = makeHarness({ job: { state: JobState.SUBMITTED, acceptedBillingFingerprint: undefined } });
+
+      await expect(service.sendToCustomer(SOW_ID, staff)).rejects.toThrow(BadRequestException);
+    });
+
+    it('refuses to send after the job changed, and sends once it is re-accepted', async () => {
+      const { service, job } = makeHarness({ liveFingerprint: 'fp-after-edit' });
+      await expect(service.sendToCustomer(SOW_ID, staff)).rejects.toThrow(/Re-accept/);
+
+      // Re-accepting is exactly re-stamping the fingerprint with the current one.
+      job.acceptedBillingFingerprint = 'fp-after-edit';
+      const sent = await service.sendToCustomer(SOW_ID, staff);
+
+      expect(sent.status).toBe(SOWStatus.SENT);
+    });
+
+    it('refuses to send a document whose figures lag the job', async () => {
+      const { service, sow } = makeHarness();
+      sow.documentStale = true;
+
+      await expect(service.sendToCustomer(SOW_ID, staff)).rejects.toThrow(/Recalculate the Fee Schedule/);
+    });
+  });
+
+  /**
+   * Signing is not a lifecycle branch.
+   *
+   * What must not differ is the *spec* half of the rule — accepted, unchanged
+   * since, document matching the job. Those blockers appear identically whether
+   * the current version is a draft or already signed. (A signed current version
+   * separately reports NO_DRAFT_TO_SEND, because there is no draft to issue
+   * until someone edits it — that is a fact about the document, not a rule about
+   * signatures.)
+   */
+  describe('the spec rule does not change once a SOW has been signed', () => {
+    const specBlockers = (list: DocumentBlocker[]): DocumentBlocker[] => list.filter((b) => b !== DocumentBlocker.NO_DRAFT_TO_SEND && b !== DocumentBlocker.DRAFT_INCOMPLETE);
+
+    const cases: Array<{ name: string; opts: any; expected: DocumentBlocker[] }> = [
+      { name: 'nothing wrong', opts: {}, expected: [] },
+      { name: 'never accepted', opts: { job: { state: JobState.SUBMITTED, acceptedBillingFingerprint: undefined } }, expected: [DocumentBlocker.NOT_ACCEPTED] },
+      { name: 'job changed since acceptance', opts: { liveFingerprint: 'fp-after-edit' }, expected: [DocumentBlocker.JOB_CHANGED_SINCE_ACCEPTANCE] }
+    ];
+
+    it.each(cases)('reports the same spec blockers on a draft and on a signed version: $name', async ({ opts, expected }) => {
+      const draft = makeHarness(opts);
+      const signed = makeHarness({ ...opts, status: SOWStatus.SIGNED });
+
+      expect(specBlockers((await draft.service.actionGate(SOW_ID)).sendBlockers)).toEqual(expected);
+      expect(specBlockers((await signed.service.actionGate(SOW_ID)).sendBlockers)).toEqual(expected);
+    });
+
+    it('reports a stale document identically either way', async () => {
+      const draft = makeHarness();
+      const signed = makeHarness({ status: SOWStatus.SIGNED });
+      draft.sow.documentStale = true;
+      signed.sow.documentStale = true;
+
+      expect(specBlockers((await draft.service.actionGate(SOW_ID)).sendBlockers)).toEqual([DocumentBlocker.DOCUMENT_STALE]);
+      expect(specBlockers((await signed.service.actionGate(SOW_ID)).sendBlockers)).toEqual([DocumentBlocker.DOCUMENT_STALE]);
+    });
+
+    it('reports NO_DRAFT_TO_SEND for an already-issued version, agreeing with sendToCustomer', async () => {
+      const { service } = makeHarness({ status: SOWStatus.SIGNED });
+      const gate = await service.actionGate(SOW_ID);
+
+      expect(gate.canSend).toBe(false);
+      expect(gate.sendBlockers).toEqual([DocumentBlocker.NO_DRAFT_TO_SEND]);
+      await expect(service.sendToCustomer(SOW_ID, staff)).rejects.toThrow();
+    });
+  });
+});
+
+describe('actionGate — countersigning', () => {
+  const signedHarness = (extra: any = {}): ReturnType<typeof makeHarness> => {
+    const h = makeHarness(extra);
+    h.versions[0].status = SOWStatus.SIGNED;
+    h.sow.activeVersionNumber = 1;
+    h.sow.currentVersionNumber = 1;
+    return h;
+  };
+
+  it('allows a countersignature on the signed version in force', async () => {
+    const { service } = signedHarness();
+    const gate = await service.actionGate(SOW_ID);
+
+    expect(gate).toMatchObject({ canCountersign: true, countersignBlockers: [] });
+  });
+
+  it('blocks it while the customer has not signed yet', async () => {
+    const { service, sow, versions } = signedHarness();
+    versions[0].status = SOWStatus.SENT;
+    sow.activeVersionNumber = 1;
+
+    expect((await service.actionGate(SOW_ID)).countersignBlockers).toEqual([DocumentBlocker.AWAITING_CUSTOMER_SIGNATURE]);
+  });
+
+  it('blocks it when staff have revised the document since the signature', async () => {
+    const { service, sow } = signedHarness();
+    sow.currentVersionNumber = 2; // an unsent draft sits above the signed version
+
+    expect((await service.actionGate(SOW_ID)).countersignBlockers).toEqual([DocumentBlocker.UNSENT_DRAFT]);
+  });
+
+  it('blocks it when the document no longer matches the job', async () => {
+    const { service, sow } = signedHarness();
+    sow.documentStale = true;
+
+    expect((await service.actionGate(SOW_ID)).countersignBlockers).toEqual([DocumentBlocker.DOCUMENT_STALE]);
+  });
+
+  it('blocks it when the job changed after it was accepted', async () => {
+    const { service } = signedHarness({ liveFingerprint: 'fp-after-edit' });
+
+    expect((await service.actionGate(SOW_ID)).countersignBlockers).toEqual([DocumentBlocker.JOB_CHANGED_SINCE_ACCEPTANCE]);
+  });
+
+  describe('finalize enforces the gate rather than trusting the resolved field', () => {
+    it('countersigns when nothing is in the way', async () => {
+      const { service } = signedHarness();
+      const v = await service.finalize(SOW_ID, 'Dr Staff', staff);
+
+      expect(v.status).toBe(SOWStatus.FINAL);
+      expect(v.staffSignature?.name).toBe('Dr Staff');
+    });
+
+    it('refuses to finalize a version staff have already revised past', async () => {
+      const { service, sow } = signedHarness();
+      sow.currentVersionNumber = 2;
+
+      await expect(service.finalize(SOW_ID, 'Dr Staff', staff)).rejects.toThrow(/newer draft/);
+    });
+
+    it('refuses to finalize a document whose figures no longer match the job', async () => {
+      const { service, sow } = signedHarness();
+      sow.documentStale = true;
+
+      await expect(service.finalize(SOW_ID, 'Dr Staff', staff)).rejects.toThrow(/Recalculate the Fee Schedule/);
+    });
+
+    it('still refuses a blank name before it even looks at the gate', async () => {
+      const { service, sow } = signedHarness();
+      sow.documentStale = true;
+
+      await expect(service.finalize(SOW_ID, '   ', staff)).rejects.toThrow(/name is required/);
+    });
+  });
+
+  /**
+   * A countersigned document gets no exemption: a price-material job change means
+   * it no longer describes the work, so it goes back through the same loop.
+   */
+  it('blocks a re-countersignature once a FINAL document has gone stale', async () => {
+    const { service, sow, versions } = signedHarness();
+    versions[0].status = SOWStatus.FINAL;
+    sow.documentStale = true;
+
+    const gate = await service.actionGate(SOW_ID);
+    expect(gate.canCountersign).toBe(false);
+    expect(gate.canSend).toBe(false);
   });
 });

--- a/src/sow/sow.model.ts
+++ b/src/sow/sow.model.ts
@@ -13,6 +13,47 @@ export enum SOWStatus {
 }
 registerEnumType(SOWStatus, { name: 'SOWStatus' });
 
+/**
+ * Why a SOW cannot move to its next lifecycle stage yet, in the order staff
+ * should resolve them. The list is ordered so the UI can render one repair
+ * sequence rather than several competing alarms.
+ */
+export enum DocumentBlocker {
+  /** The lab has not accepted this job's spec. */
+  NOT_ACCEPTED = 'NOT_ACCEPTED',
+  /** The spec moved after it was accepted, so the acceptance no longer covers it. */
+  JOB_CHANGED_SINCE_ACCEPTANCE = 'JOB_CHANGED_SINCE_ACCEPTANCE',
+  /** The document still bills the job's earlier figures; Recalculate then save. */
+  DOCUMENT_STALE = 'DOCUMENT_STALE',
+  /** A required section is missing or empty. */
+  DRAFT_INCOMPLETE = 'DRAFT_INCOMPLETE',
+  /** The current version has already been issued; editing starts a fresh draft. */
+  NO_DRAFT_TO_SEND = 'NO_DRAFT_TO_SEND',
+  /** A draft sits above the version the customer holds; it has to go out and be signed first. */
+  UNSENT_DRAFT = 'UNSENT_DRAFT',
+  /** The version in force has not been signed by the customer yet. */
+  AWAITING_CUSTOMER_SIGNATURE = 'AWAITING_CUSTOMER_SIGNATURE'
+}
+registerEnumType(DocumentBlocker, { name: 'DocumentBlocker' });
+
+@ObjectType({ description: 'Which lifecycle actions this SOW currently permits, and what is in the way of each.' })
+export class SowActionGate {
+  @Field({ description: 'True when nothing blocks issuing the current draft to the customer.' })
+  canSend: boolean;
+
+  @Field(() => [DocumentBlocker], { description: 'What stands between the current draft and a send, in repair order.' })
+  sendBlockers: DocumentBlocker[];
+
+  @Field({ description: 'True when nothing blocks countersigning the signed version in force.' })
+  canCountersign: boolean;
+
+  @Field(() => [DocumentBlocker], { description: 'What stands between the signed version and a countersignature, in repair order.' })
+  countersignBlockers: DocumentBlocker[];
+
+  @Field(() => [String], { description: 'Human-readable labels for the required sections still missing, when DRAFT_INCOMPLETE is present.' })
+  missingFields: string[];
+}
+
 export enum SOWAdjustmentType {
   DISCOUNT = 'DISCOUNT',
   ADDITIONAL_COST = 'ADDITIONAL_COST',

--- a/src/sow/sow.resolver.ts
+++ b/src/sow/sow.resolver.ts
@@ -1,5 +1,5 @@
 import { Resolver, Query, Mutation, Args, ID, Int, ResolveField, Parent } from '@nestjs/graphql';
-import { SOW, SOWStatus } from './sow.model';
+import { SOW, SOWStatus, SowActionGate } from './sow.model';
 import { SOWService } from './sow.service';
 import { SowVersionService } from './sow-version.service';
 import { SowVersion, SowCalculatedValue, SowVersionService as SowVersionServiceLine } from './sow-version.model';
@@ -96,9 +96,19 @@ export class SOWResolver {
     return this.sowService.upsertForJob(jobId, { ...input, jobId, createdBy });
   }
 
+  /**
+   * The pre-versioning signature path. It writes signatures onto the SOW root
+   * and flips status to SIGNED without going through the version state machine,
+   * so it bypasses every check signSow makes — including the send gate. No UI
+   * calls it; staff-gated here so it cannot be driven from a customer token
+   * while it waits to be deleted.
+   *
+   * @deprecated Use signSow / finalizeSow.
+   */
   @Mutation(() => SOW, {
-    description: 'Submit a signature for an SOW (client or technician). Idempotent per role; the service checks job ownership for CLIENT and staff role for TECHNICIAN.'
+    description: 'Deprecated, staff-only. Legacy pre-versioning signature path; use signSow instead.'
   })
+  @Roles(Role.DamplabStaff)
   async submitSOWSignature(@Args('input', { type: () => SubmitSOWSignatureInput }) input: SubmitSOWSignatureInput, @CurrentUser() user: User): Promise<SOW> {
     return this.sowService.submitSignature(input, user);
   }
@@ -110,13 +120,14 @@ export class SOWResolver {
 
   // ---------------------------------------------------------------------------
   // Live Fee Schedule figures — recomputed fresh on every query, independent of
-  // whatever is stored on the SOW or frozen into a version. What the "Stale"
-  // chip and Recalculate button on the Fee Schedule compare local edits against.
+  // whatever is stored on the SOW or frozen into a version. These are what the
+  // Fee Schedule renders: service lines belong to the job spec, and the document
+  // shows them read-only rather than holding an editable copy.
   // ---------------------------------------------------------------------------
 
   @ResolveField(() => [SowVersionServiceLine], {
     description:
-      'The SOW\'s current service lines and their costs, read fresh on every query. Kept in sync with the job\'s services/category by syncSowServicesFromJobWorkflows — this is what the Fee Schedule "Stale" chip and Recalculate compare a local draft against.'
+      "The SOW's current service lines and their costs, read fresh on every query. Kept in sync with the job's services/category by syncSowServicesFromJobWorkflows — this is what the Fee Schedule renders, since service prices belong to the job spec rather than the document."
   })
   async liveServices(@Parent() sow: SOW): Promise<SowVersionServiceLine[]> {
     const job = await this.jobService.findById(sow.jobId);
@@ -127,6 +138,13 @@ export class SOWResolver {
   async liveCustomerCategory(@Parent() sow: SOW): Promise<CustomerCategory | null> {
     const job = await this.jobService.findById(sow.jobId);
     return job?.customerCategory ?? null;
+  }
+
+  @ResolveField(() => SowActionGate, {
+    description: 'Which lifecycle actions this SOW permits and what is in the way of each. Advisory only — sendSowToCustomer and finalizeSow enforce the same rules server-side.'
+  })
+  async actionGate(@Parent() sow: SOW): Promise<SowActionGate> {
+    return this.sowVersionService.actionGate(String((sow as any)._id));
   }
 
   // ---------------------------------------------------------------------------

--- a/src/sow/sow.service.ts
+++ b/src/sow/sow.service.ts
@@ -16,9 +16,6 @@ import { labCalendarDay, adjustmentAmount, adjustmentMultiplier } from './sow-fi
 import { WorkflowService } from '../workflow/workflow.service';
 import { WorkflowNodeService } from '../workflow/services/node.service';
 
-/** Money, kept to cents: a unit price times a multiplier is prone to binary drift. */
-const round2 = (n: number): number => Math.round(n * 100) / 100;
-
 @Injectable()
 export class SOWService {
   private readonly logger = new Logger(SOWService.name);
@@ -219,14 +216,92 @@ export class SOWService {
       type: adj.type,
       description: adj.description,
       // The client's `amount` is never trusted where it can be derived: a caller
-      // that sends a unit amount gets the product, computed here, the same way
-      // a service line's total is derived from its unit price above.
+      // that sends a unit amount gets the product, computed here.
       amount: adjustmentAmount(adj),
       unitAmount: adj.unitAmount == null ? undefined : Number(adj.unitAmount),
       multiplier: adj.unitAmount == null ? undefined : adjustmentMultiplier(adj),
       category: adj.category,
       reason: adj.reason
     }));
+  }
+
+  /**
+   * The SOW service lines a job's workflows currently imply, in node order.
+   *
+   * The single source of service-line figures: the workflow sync writes these
+   * onto the SOW, and the accept-before-send gate fingerprints them to decide
+   * whether the spec still matches what staff accepted. Lives here rather than
+   * on JobResolver because both of those callers need it and neither owns it.
+   */
+  async collectSowServiceInputs(job: Job, existingServices: any[] = []): Promise<any[]> {
+    const orderedNodes: any[] = [];
+    for (const workflowId of job.workflows ?? []) {
+      const workflow = await this.workflowService.findById(String(workflowId));
+      if (!workflow) continue;
+
+      const nodeIds = (workflow.nodes ?? []).map((n: any) => String(n));
+      if (!nodeIds.length) continue;
+
+      const nodes = await this.workflowNodeService.getByIDs(nodeIds);
+      const byId = new Map(nodes.map((n: any) => [String(n._id), n]));
+
+      for (const nodeId of nodeIds) {
+        const node = byId.get(nodeId);
+        if (node) orderedNodes.push(node);
+      }
+    }
+
+    return orderedNodes.map((node: any, idx: number) => {
+      const existing = existingServices[idx];
+      const serviceId = String(node.service?._id ?? node.service);
+
+      return {
+        id: serviceId,
+        name: existing?.name ?? node.label ?? 'Service',
+        description: existing?.description ?? node.label ?? 'Service',
+        // A unit price, not a line total: transformServices multiplies whatever
+        // arrives here by the node's multiplier when the service record carries
+        // no price of its own.
+        //
+        // The job's node price always wins. The stored SOW figure used to be
+        // preferred, which was correct while the SOW editor could override a
+        // unit price — but it also meant a workflow edit that should reprice a
+        // line silently didn't, leaving a stale figure on the document forever.
+        // Service lines are no longer document-editable, so there is nothing on
+        // the SOW side worth preserving here.
+        unitCost: node.price ?? 0,
+        cost: node.price ?? 0,
+        category: existing?.category ?? 'molecular-biology',
+        formData: node.formData ?? []
+      };
+    });
+  }
+
+  /**
+   * The job's billing fingerprint: what the accept-before-send gate compares.
+   *
+   * Deliberately derived from the job's own workflows (collectSowServiceInputs)
+   * rather than from sow.services, for two reasons. Acceptance usually happens
+   * before a SOW exists, so there is nothing on the document side to read; and
+   * both sides of the comparison have to be computed the same way or every
+   * check would report drift that isn't there.
+   *
+   * Consequence, intended: an admin catalogue price edit moves what
+   * transformServices writes onto the SOW but moves neither node.price nor the
+   * category, so it does not re-lock the send. The document's own staleness
+   * signal covers that case.
+   */
+  async jobBillingFingerprint(job: Job): Promise<string> {
+    const services = await this.collectSowServiceInputs(job);
+    return SowVersionService.jobBillingFingerprint(
+      // `multiplier` is left out rather than recomputed: node.price is already
+      // unitCost x multiplier (calculateServiceCost returns the breakdown's
+      // `cost`, and the multiplier includes __runCount), so a run-count or
+      // sample-count change moves the figure below on its own. Both sides of the
+      // gate's comparison run through here, so omitting it cannot cause drift.
+      services.map((s) => ({ serviceId: String(s.id), name: s.name, cost: Number(s.cost) || 0, unitCost: s.unitCost, multiplier: undefined })),
+      (job as any).customerCategory ?? null
+    );
   }
 
   /**
@@ -239,69 +314,31 @@ export class SOWService {
   }
 
   /**
-   * Writes the billing figures a staff member changed in the SOW editor back to
-   * the billing core, then recomputes the totals.
+   * Writes the adjustments a staff member changed in the SOW editor back to the
+   * billing core, then recomputes the totals.
    *
-   * Deliberately does not go through transformServices. That helper reprices each
-   * line from the service record plus the node's formData, and the document editor
-   * has no formData to give it — so routing a document save through it would drop
-   * the run-count multiplier and reprice a 70-run job as a 1-run job. Here the
-   * cost the staff member sees is the cost that is stored; only baseCost and
-   * totalCost are derived, and only from values already on the SOW.
+   * Service lines are deliberately NOT writable from the document. Their figures
+   * come from the job spec — the thing the customer proposed and the lab
+   * accepted — via transformServices on the workflow sync path, which is the
+   * single writer. Staff alter what a document bills by adding a DISCOUNT or
+   * ADDITIONAL_COST adjustment, which the customer can see as its own line with
+   * its own reason, rather than by silently rewriting a price the customer
+   * already agreed to.
    *
-   * Costs are matched by position, not serviceId — a job can legitimately use the
-   * same catalogue service more than once (e.g. two PCR steps at different run
-   * counts), so serviceId is not unique per line. A serviceId-keyed override map
-   * would collapse every line sharing that id onto whichever cost came last in
-   * the request, corrupting the other lines' totals. The editor never adds,
-   * removes, or reorders lines — SowFieldSourceControls only edits the cost
-   * already at a given index — so position is the reliable correlation key here,
-   * same as collectSowServiceInputs already assumes elsewhere. If the arrays
-   * have diverged (e.g. a workflow sync changed the billable lines while the
-   * editor was open) a line is left unchanged rather than risk writing its cost
-   * onto the wrong service — that's what "applied only to lines that already
-   * exist" means in practice.
+   * baseCost and totalCost are still derived here, and only from values already
+   * on the SOW.
    */
-  async applyDocumentBilling(
-    sowId: string,
-    changes: { serviceCosts?: Array<{ serviceId: string; unitCost?: number; cost?: number }>; adjustments?: CreateSOWInput['pricing']['adjustments'] }
-  ): Promise<SOW> {
+  async applyDocumentBilling(sowId: string, changes: { adjustments?: CreateSOWInput['pricing']['adjustments'] }): Promise<SOW> {
     const sow = await this.sowModel.findById(sowId).exec();
     if (!sow) throw new NotFoundException(`SOW with ID ${sowId} not found`);
 
-    const incoming = changes.serviceCosts ?? [];
-    const sameLength = incoming.length === (sow.services ?? []).length;
-
-    const services = (sow.services ?? []).map((service, i) => {
-      if (!sameLength) return service;
-      const line = incoming[i];
-      if (String(line.serviceId) !== String(service.serviceId ?? service._id)) return service;
-      // Staff edit the unit price; the line total follows from it and the
-      // multiplier the workflow baked in, which the document cannot edit.
-      // `!= null` before Number(): the editor sends an explicit null for a line
-      // that has no unit price yet, and Number(null) is a finite 0 — which would
-      // zero out the line instead of falling through to the cost path below.
-      const unit = line.unitCost == null ? NaN : Number(line.unitCost);
-      const multiplier = Number.isFinite(Number(service.multiplier)) && Number(service.multiplier) > 0 ? Number(service.multiplier) : 1;
-      if (Number.isFinite(unit) && unit >= 0) {
-        return { ...service, unitCost: unit, multiplier, cost: round2(unit * multiplier) };
-      }
-
-      // A caller with no unit price to send — a document saved before unit
-      // prices were recorded — still writes the total through as it always did.
-      const override = Number(line.cost);
-      if (!Number.isFinite(override) || override < 0) return service;
-      return { ...service, cost: override };
-    });
-
+    const services = sow.services ?? [];
     const adjustments = changes.adjustments ? this.transformPricingAdjustments(changes.adjustments) : sow.pricing?.adjustments ?? [];
 
     const baseCost = this.calculateBaseCost(services);
     const totalCost = this.calculateTotalCost(baseCost, adjustments);
 
-    const updated = await this.sowModel
-      .findByIdAndUpdate(sowId, { $set: { services, pricing: { ...(sow.pricing ?? {}), baseCost, adjustments, totalCost }, updatedAt: new Date() } }, { new: true })
-      .exec();
+    const updated = await this.sowModel.findByIdAndUpdate(sowId, { $set: { pricing: { ...(sow.pricing ?? {}), baseCost, adjustments, totalCost }, updatedAt: new Date() } }, { new: true }).exec();
 
     if (!updated) throw new NotFoundException(`SOW with ID ${sowId} not found`);
     return updated;
@@ -542,7 +579,6 @@ export class SOWService {
     }
     if (updateSOWInput.terms !== undefined) updateData.terms = updateSOWInput.terms;
     if (updateSOWInput.additionalInformation !== undefined) updateData.additionalInformation = updateSOWInput.additionalInformation;
-    if (updateSOWInput.status !== undefined) updateData.status = updateSOWInput.status;
 
     const updatedSOW = await this.sowModel.findByIdAndUpdate(id, { $set: updateData }, { new: true }).exec();
     if (!updatedSOW) {
@@ -689,8 +725,8 @@ export class SOWService {
         resources: createSOWInput.resources,
         pricing: createSOWInput.pricing,
         terms: createSOWInput.terms,
-        additionalInformation: createSOWInput.additionalInformation,
-        status: createSOWInput.status
+        additionalInformation: createSOWInput.additionalInformation
+        // status is not forwarded: the version state machine owns it.
       };
       result = await this.update(existingSOW._id, updateInput);
     } else {


### PR DESCRIPTION
# Description

Following discussions with Lena and Raven, agreed on changes discussed here: https://docs.google.com/document/d/1YN2UWQRXoC4o81hc74B40gm29--huyRUQR0CBqQokZ0/edit?tab=t.gjrln2fhekxc#heading=h.5dpetlurr2w1

Key changes:
 - Job must be accepted before an SOW can be sent
 - Fee Schedule service line prices now unchangeable except through job spec edits ('additional cost' and 'discount' still available)

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
