### PR TITLE
feat: extend inventory model with new fields and add type migration s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json --forceExit --detectOpenHandles",
     "initdb": "cd ./scripts; npm install; npm run build; node --env-file=../.env ./bin/dev load all",
-    "migrate:sows": "node --env-file=.env dist/src/sow/migrate-sows.js"
+    "migrate:sows": "node --env-file=.env dist/src/sow/migrate-sows.js",
+    "migrate:inventory-types": "node --env-file=.env dist/src/inventory/migrate-inventory-types.js"
   },
   "dependencies": {
     "@apollo/server": "^5.2.0",

--- a/src/inventory/dtos/create.dto.ts
+++ b/src/inventory/dtos/create.dto.ts
@@ -1,13 +1,16 @@
 import { Field, InputType, OmitType } from '@nestjs/graphql';
-import { InventoryItem, StationPlacementInput } from '../inventory.model';
+import { InventoryItem, StationPlacementInput, DimensionInput } from '../inventory.model';
 
 /**
- * `placements` must be re-declared: OmitType reuses the model's field metadata,
- * and the model types it as the @ObjectType `StationPlacement`, which is not a
- * legal GraphQL input. Overriding it here binds the @InputType twin instead.
+ * `placements` and `dimensions` must be re-declared: OmitType reuses the model's
+ * field metadata, and the model types them as @ObjectType classes, which are not
+ * legal GraphQL inputs. Overriding them here binds the @InputType twins instead.
  */
 @InputType()
-export class CreateInventoryItem extends OmitType(InventoryItem, ['id', 'isDeleted', 'placements'] as const, InputType) {
+export class CreateInventoryItem extends OmitType(InventoryItem, ['id', 'isDeleted', 'placements', 'dimensions'] as const, InputType) {
   @Field(() => [StationPlacementInput], { nullable: true })
   placements?: StationPlacementInput[];
+
+  @Field(() => [DimensionInput], { nullable: true })
+  dimensions?: DimensionInput[];
 }

--- a/src/inventory/dtos/update.dto.ts
+++ b/src/inventory/dtos/update.dto.ts
@@ -1,9 +1,12 @@
 import { Field, InputType, OmitType, PartialType } from '@nestjs/graphql';
-import { InventoryItem, StationPlacementInput } from '../inventory.model';
+import { InventoryItem, StationPlacementInput, DimensionInput } from '../inventory.model';
 
-/** See CreateInventoryItem for why `placements` is re-declared rather than inherited. */
+/** See CreateInventoryItem for why `placements` and `dimensions` are re-declared rather than inherited. */
 @InputType()
-export class InventoryItemChange extends PartialType(OmitType(InventoryItem, ['id', 'placements'] as const), InputType) {
+export class InventoryItemChange extends PartialType(OmitType(InventoryItem, ['id', 'placements', 'dimensions'] as const), InputType) {
   @Field(() => [StationPlacementInput], { nullable: true })
   placements?: StationPlacementInput[];
+
+  @Field(() => [DimensionInput], { nullable: true })
+  dimensions?: DimensionInput[];
 }

--- a/src/inventory/inventory.model.ts
+++ b/src/inventory/inventory.model.ts
@@ -81,7 +81,10 @@ export class DimensionInput {
 }
 
 const DimensionSchema = new mongoose.Schema(
-  { value: { type: Number, required: true }, unit: { type: String, required: true } },
+  {
+    value: { type: Number, required: true },
+    unit: { type: String, required: true }
+  },
   { _id: false }
 );
 

--- a/src/inventory/inventory.model.ts
+++ b/src/inventory/inventory.model.ts
@@ -44,16 +44,46 @@ export const StationPlacementSchema = new mongoose.Schema(
 
 /**
  * Coarse category for filtering and grouping on the availability board.
- * Open-ended on purpose — extend as the lab adds new categories of gear.
  */
 export enum InventoryItemType {
+  /** @deprecated Use EQUIPMENT. Kept for backward-compatible reads until migration runs. */
   ROBOT = 'ROBOT',
+  /** @deprecated Use EQUIPMENT. Kept for backward-compatible reads until migration runs. */
   MACHINE = 'MACHINE',
+  /** @deprecated Use EQUIPMENT. Kept for backward-compatible reads until migration runs. */
   INSTRUMENT = 'INSTRUMENT',
-  CONSUMABLE = 'CONSUMABLE',
-  OTHER = 'OTHER'
+  /** @deprecated Use EQUIPMENT or HOOD/STORAGE. Kept for backward-compatible reads until migration runs. */
+  OTHER = 'OTHER',
+  EQUIPMENT = 'EQUIPMENT',
+  HOOD = 'HOOD',
+  STORAGE = 'STORAGE',
+  CONSUMABLE = 'CONSUMABLE'
 }
 registerEnumType(InventoryItemType, { name: 'InventoryItemType' });
+
+/** A single dimension measurement (e.g. 12 cm, 5 kg). */
+@ObjectType()
+export class Dimension {
+  @Field({ description: 'Numeric value of the measurement.' })
+  value: number;
+
+  @Field({ description: 'Unit of measurement (e.g. cm, mm, kg).' })
+  unit: string;
+}
+
+@InputType()
+export class DimensionInput {
+  @Field()
+  value: number;
+
+  @Field()
+  unit: string;
+}
+
+const DimensionSchema = new mongoose.Schema(
+  { value: { type: Number, required: true }, unit: { type: String, required: true } },
+  { _id: false }
+);
 
 /** How a bookable item is billed. */
 export enum InventoryRateType {
@@ -82,10 +112,10 @@ export class InventoryItem {
   @Field({ description: 'Human readable name (e.g. "OT-2 #1", "Bioanalyzer").' })
   name: string;
 
-  @Prop({ required: false, default: InventoryItemType.MACHINE, type: String, enum: Object.values(InventoryItemType) })
+  @Prop({ required: false, default: InventoryItemType.EQUIPMENT, type: String, enum: Object.values(InventoryItemType) })
   @Field(() => InventoryItemType, {
     nullable: true,
-    defaultValue: InventoryItemType.MACHINE,
+    defaultValue: InventoryItemType.EQUIPMENT,
     description: 'Coarse category for grouping on the availability board.'
   })
   type?: InventoryItemType;
@@ -145,6 +175,34 @@ export class InventoryItem {
     description: 'Stations this equipment is placed at, with the quantity at each (equipment→station map). Locational only — does not affect booking capacity.'
   })
   placements: StationPlacement[];
+
+  @Prop({ required: false, unique: true, sparse: true })
+  @Field({ nullable: true, description: 'System-generated unique identifier (e.g. INV-0001). Not the Mongo _id.' })
+  uniqueId?: string;
+
+  @Prop({ type: [String], default: [] })
+  @Field(() => [String], { description: 'Filterable tags for finer categorisation (e.g. "Analytical Equipment", "Centrifuge").' })
+  tags: string[];
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Manufacturer model number. Items with the same model # are the same type of equipment.' })
+  modelNumber?: string;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Serial number for tracking individual units. Internal use only — hidden from non-staff.' })
+  serialNumber?: string;
+
+  @Prop({ required: false, default: false })
+  @Field(() => Boolean, { nullable: true, defaultValue: false, description: 'Whether this item has an active service contract.' })
+  hasServiceContract?: boolean;
+
+  @Prop({ required: false, type: Date })
+  @Field({ nullable: true, description: 'Expiration date of the service contract, if any.' })
+  serviceContractExpiration?: Date;
+
+  @Prop({ type: [DimensionSchema], default: [] })
+  @Field(() => [Dimension], { description: 'Physical dimensions of the equipment (up to 3 measurements).' })
+  dimensions: Dimension[];
 
   @Prop({ required: false, default: false })
   @Field(() => Boolean, {

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -79,7 +79,22 @@ export class InventoryService {
   }
 
   async create(item: CreateInventoryItem): Promise<InventoryItem> {
+    if (!item.uniqueId) {
+      item.uniqueId = await this.nextUniqueId();
+    }
     return this.inventoryModel.create(item);
+  }
+
+  /** Generates the next sequential unique ID (INV-0001, INV-0002, …). */
+  private async nextUniqueId(): Promise<string> {
+    const last = await this.inventoryModel
+      .findOne({ uniqueId: { $regex: /^INV-\d+$/ } })
+      .sort({ uniqueId: -1 })
+      .select('uniqueId')
+      .lean()
+      .exec();
+    const lastNum = last?.uniqueId ? parseInt(last.uniqueId.replace('INV-', ''), 10) : 0;
+    return `INV-${String(lastNum + 1).padStart(4, '0')}`;
   }
 
   async update(item: InventoryItem, changes: InventoryItemChange): Promise<InventoryItem> {

--- a/src/inventory/migrate-inventory-types.ts
+++ b/src/inventory/migrate-inventory-types.ts
@@ -26,10 +26,7 @@ interface MigrationReport {
   failed: Array<{ id: string; error: string }>;
 }
 
-export async function migrateInventoryTypes(
-  db: mongoose.mongo.Db,
-  opts: { dryRun?: boolean; log?: (msg: string) => void } = {}
-): Promise<MigrationReport> {
+export async function migrateInventoryTypes(db: mongoose.mongo.Db, opts: { dryRun?: boolean; log?: (msg: string) => void } = {}): Promise<MigrationReport> {
   const log = opts.log ?? console.log;
   const items = db.collection('inventoryitems');
 

--- a/src/inventory/migrate-inventory-types.ts
+++ b/src/inventory/migrate-inventory-types.ts
@@ -1,0 +1,108 @@
+/**
+ * One-shot migration: map legacy InventoryItemType values to the new enum.
+ *
+ * Run with:
+ *   npm run migrate:inventory-types            # apply
+ *   npm run migrate:inventory-types -- --dry   # report only
+ *
+ * Idempotent: items already using the new enum values are skipped.
+ */
+import mongoose from 'mongoose';
+
+const TYPE_MAP: Record<string, string> = {
+  ROBOT: 'EQUIPMENT',
+  MACHINE: 'EQUIPMENT',
+  INSTRUMENT: 'EQUIPMENT',
+  OTHER: 'EQUIPMENT'
+  // CONSUMABLE stays CONSUMABLE — no mapping needed
+};
+
+const NEW_TYPES = new Set(['EQUIPMENT', 'HOOD', 'STORAGE', 'CONSUMABLE']);
+
+interface MigrationReport {
+  scanned: number;
+  migrated: number;
+  skipped: number;
+  failed: Array<{ id: string; error: string }>;
+}
+
+export async function migrateInventoryTypes(
+  db: mongoose.mongo.Db,
+  opts: { dryRun?: boolean; log?: (msg: string) => void } = {}
+): Promise<MigrationReport> {
+  const log = opts.log ?? console.log;
+  const items = db.collection('inventoryitems');
+
+  const report: MigrationReport = { scanned: 0, migrated: 0, skipped: 0, failed: [] };
+  const cursor = items.find({});
+
+  for await (const raw of cursor) {
+    report.scanned += 1;
+    const id = String(raw._id);
+    const currentType = raw.type as string | undefined;
+
+    try {
+      if (!currentType || NEW_TYPES.has(currentType)) {
+        report.skipped += 1;
+        continue;
+      }
+
+      const newType = TYPE_MAP[currentType];
+      if (!newType) {
+        log(`unknown type "${currentType}" on ${raw.name ?? id}, mapping to EQUIPMENT`);
+      }
+
+      const mappedType = newType ?? 'EQUIPMENT';
+
+      if (opts.dryRun) {
+        log(`[dry] ${raw.name ?? id}: ${currentType} → ${mappedType}`);
+        report.migrated += 1;
+        continue;
+      }
+
+      await items.updateOne({ _id: raw._id }, { $set: { type: mappedType } });
+      report.migrated += 1;
+      log(`migrated ${raw.name ?? id}: ${currentType} → ${mappedType}`);
+    } catch (error) {
+      report.failed.push({ id, error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  return report;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry') || process.argv.includes('--dry-run');
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is not set. Run with: node --env-file=.env dist/src/inventory/migrate-inventory-types.js');
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  try {
+    const db = mongoose.connection.db;
+    if (!db) throw new Error('No database handle after connect');
+
+    console.log(dryRun ? 'Dry run — no writes will be made.' : 'Migrating inventory types...');
+    const report = await migrateInventoryTypes(db, { dryRun });
+
+    console.log('\n--- Inventory type migration ---');
+    console.log(`scanned : ${report.scanned}`);
+    console.log(`migrated: ${report.migrated}${dryRun ? ' (would be)' : ''}`);
+    console.log(`skipped : ${report.skipped} (already new type)`);
+    console.log(`failed  : ${report.failed.length}`);
+    for (const f of report.failed) console.error(`  ${f.id}: ${f.error}`);
+
+    if (report.failed.length > 0) process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Extends the InventoryItem model with new fields to support the lab's
updated inventory spreadsheet template and upcoming bulk upload feature.

### New fields
- `uniqueId` — system-generated identifier (INV-0001 format), auto-assigned on create
- `tags` — string array for filterable sub-categories (e.g. "Analytical Equipment", "Centrifuge")
- `modelNumber` — manufacturer model number to link identical equipment
- `serialNumber` — serial number for individual unit tracking (internal/staff-only)
- `hasServiceContract` — whether the item has an active service contract
- `serviceContractExpiration` — contract expiration date
- `dimensions` — array of {value, unit} for physical measurements

### Type enum changes
- Added new values: `EQUIPMENT`, `HOOD`, `STORAGE` (alongside existing `CONSUMABLE`)
- Legacy values (`ROBOT`, `MACHINE`, `INSTRUMENT`, `OTHER`) retained for backward compatibility
- Default type changed from `MACHINE` to `EQUIPMENT`

### Migration script
- `npm run migrate:inventory-types` maps legacy enum values to new ones
- Supports `--dry` flag for preview
- Idempotent, safe to re-run
- Run after deploying: `npm run build && npm run migrate:inventory-types`

All new fields are optional/nullable — no breaking changes to existing data or queries