### PR TITLE
Feature/inventory upload enhancements

### DIFF
--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -4,7 +4,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
 import { Reflector } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
-import { ROLES_KEY } from './roles/roles.decorator';
+import { IS_PUBLIC_KEY, ROLES_KEY } from './roles/roles.decorator';
 import { Role } from './roles/roles.enum';
 import { User } from './user.interface';
 import { ApiKeyService } from '../api-key/api-key.service';
@@ -14,6 +14,9 @@ export class AuthRolesGuard implements CanActivate {
   constructor(private configService: ConfigService, private jwtService: JwtService, private reflector: Reflector, private apiKeyService: ApiKeyService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [context.getHandler(), context.getClass()]);
+    if (isPublic) return true;
+
     let request;
     if (context.getType() === 'http') {
       request = context.switchToHttp().getRequest();

--- a/src/auth/roles/roles.decorator.ts
+++ b/src/auth/roles/roles.decorator.ts
@@ -2,5 +2,7 @@ import { SetMetadata, CustomDecorator } from '@nestjs/common';
 import { Role } from './roles.enum';
 
 export const ROLES_KEY = 'roles';
+export const IS_PUBLIC_KEY = 'isPublic';
 
 export const Roles = (...roles: Role[]): CustomDecorator<string> => SetMetadata(ROLES_KEY, roles);
+export const Public = (): CustomDecorator<string> => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/booking/booking.model.ts
+++ b/src/booking/booking.model.ts
@@ -1,7 +1,7 @@
 import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
 import mongoose, { Document } from 'mongoose';
 import { Field, ID, ObjectType, Float, Int, registerEnumType } from '@nestjs/graphql';
-import { InventoryItem, InventoryItemType } from '../inventory/inventory.model';
+import { InventoryItem } from '../inventory/inventory.model';
 
 /** Timed (machine, by the hour) vs quantity (consumable, by the unit). */
 export enum BookingKind {
@@ -45,9 +45,9 @@ export class Booking {
   @Field({ nullable: true, description: 'Snapshot of the item name at booking time.' })
   inventoryName?: string;
 
-  @Prop({ required: false, type: String, enum: Object.values(InventoryItemType) })
-  @Field(() => InventoryItemType, { nullable: true, description: 'Snapshot of the item type.' })
-  inventoryType?: InventoryItemType;
+  @Prop({ required: false, type: String })
+  @Field(() => String, { nullable: true, description: 'Snapshot of the item type.' })
+  inventoryType?: string;
 
   // --- Owner: who the booking is for and who gets billed ---
   @Prop({ required: true })

--- a/src/booking/booking.service.ts
+++ b/src/booking/booking.service.ts
@@ -4,7 +4,6 @@ import { Model } from 'mongoose';
 import { Booking, BookingBillingStatus, BookingDocument, BookingKind, BookingStatus } from './booking.model';
 import { CreateBookingInput } from './dtos/create-booking.input';
 import { InventoryService } from '../inventory/inventory.service';
-import { InventoryItemType } from '../inventory/inventory.model';
 import { AvailabilityService } from '../availability/availability.service';
 
 interface ActorIdentity {
@@ -52,7 +51,7 @@ export class BookingService {
   private inferKind(item: any): BookingKind {
     if (item.rateType === 'PER_UNIT') return BookingKind.QUANTITY;
     if (item.rateType === 'HOURLY') return BookingKind.TIMED;
-    return item.type === InventoryItemType.CONSUMABLE ? BookingKind.QUANTITY : BookingKind.TIMED;
+    return item.type === 'CONSUMABLE' ? BookingKind.QUANTITY : BookingKind.TIMED;
   }
 
   async create(input: CreateBookingInput, actor: ActorIdentity): Promise<Booking> {

--- a/src/inventory/inventory.model.ts
+++ b/src/inventory/inventory.model.ts
@@ -42,18 +42,8 @@ export const StationPlacementSchema = new mongoose.Schema(
   { _id: false }
 );
 
-/**
- * Coarse category for filtering and grouping on the availability board.
- * Open-ended on purpose — extend as the lab adds new categories of gear.
- */
-export enum InventoryItemType {
-  ROBOT = 'ROBOT',
-  MACHINE = 'MACHINE',
-  INSTRUMENT = 'INSTRUMENT',
-  CONSUMABLE = 'CONSUMABLE',
-  OTHER = 'OTHER'
-}
-registerEnumType(InventoryItemType, { name: 'InventoryItemType' });
+/** Suggested values for the type field — not enforced, users can add new ones. */
+export const SUGGESTED_INVENTORY_TYPES = ['EQUIPMENT', 'HOOD', 'STORAGE', 'CONSUMABLE'];
 
 /** How a bookable item is billed. */
 export enum InventoryRateType {
@@ -82,13 +72,13 @@ export class InventoryItem {
   @Field({ description: 'Human readable name (e.g. "OT-2 #1", "Bioanalyzer").' })
   name: string;
 
-  @Prop({ required: false, default: InventoryItemType.MACHINE, type: String, enum: Object.values(InventoryItemType) })
-  @Field(() => InventoryItemType, {
+  @Prop({ required: false, default: 'EQUIPMENT', type: String })
+  @Field(() => String, {
     nullable: true,
-    defaultValue: InventoryItemType.MACHINE,
-    description: 'Coarse category for grouping on the availability board.'
+    defaultValue: 'EQUIPMENT',
+    description: 'Coarse category for grouping on the availability board. Free string — suggested values: EQUIPMENT, HOOD, STORAGE, CONSUMABLE.'
   })
-  type?: InventoryItemType;
+  type?: string;
 
   @Prop({ required: false })
   @Field({ nullable: true, description: 'Free-text description (model, capabilities, notes).' })

--- a/src/inventory/inventory.model.ts
+++ b/src/inventory/inventory.model.ts
@@ -143,6 +143,10 @@ export class InventoryItem {
     description: 'Soft-deleted: hidden from pickers but still resolvable for historical nodes.'
   })
   isDeleted?: boolean;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Username or sub of whoever last created or modified this item.' })
+  lastModifiedBy?: string;
 }
 
 export type InventoryItemDocument = InventoryItem & mongoose.Document;

--- a/src/inventory/inventory.module.ts
+++ b/src/inventory/inventory.module.ts
@@ -4,10 +4,18 @@ import { InventoryItem, InventoryItemSchema } from './inventory.model';
 import { InventoryService } from './inventory.service';
 import { InventoryResolver } from './inventory.resolver';
 import { InventoryItemPipe } from './inventory.pipe';
+import { UploadLog, UploadLogSchema } from './upload-log.model';
+import { UploadLogService } from './upload-log.service';
+import { UploadLogResolver } from './upload-log.resolver';
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: InventoryItem.name, schema: InventoryItemSchema }])],
-  providers: [InventoryService, InventoryResolver, InventoryItemPipe],
+  imports: [
+    MongooseModule.forFeature([
+      { name: InventoryItem.name, schema: InventoryItemSchema },
+      { name: UploadLog.name, schema: UploadLogSchema }
+    ])
+  ],
+  providers: [InventoryService, InventoryResolver, InventoryItemPipe, UploadLogService, UploadLogResolver],
   exports: [InventoryService]
 })
 export class InventoryModule {}

--- a/src/inventory/inventory.resolver.ts
+++ b/src/inventory/inventory.resolver.ts
@@ -7,7 +7,7 @@ import { CreateInventoryItem } from './dtos/create.dto';
 import { InventoryItemChange } from './dtos/update.dto';
 
 import { AuthRolesGuard } from '../auth/auth.guard';
-import { Roles } from '../auth/roles/roles.decorator';
+import { Public, Roles } from '../auth/roles/roles.decorator';
 import { Role } from '../auth/roles/roles.enum';
 
 @Resolver(() => InventoryItem)
@@ -25,6 +25,19 @@ export class InventoryResolver {
   @Query(() => [InventoryItem], { description: 'Active (non-deleted) inventory items for catalog pickers.' })
   async activeInventoryItems(): Promise<InventoryItem[]> {
     return this.inventoryService.findAllActive();
+  }
+
+  /** Public inventory list — no auth required, sensitive fields (uniqueId, serialNumber) stripped. */
+  @Public()
+  @Query(() => [InventoryItem], { description: 'Public inventory list with sensitive fields hidden.' })
+  async publicInventoryItems(): Promise<InventoryItem[]> {
+    const items = await this.inventoryService.findAllActive();
+    return items.map((item) => {
+      const doc = { ...item } as any;
+      doc.uniqueId = undefined;
+      doc.serialNumber = undefined;
+      return doc;
+    });
   }
 
   @Mutation(() => InventoryItem)

--- a/src/inventory/inventory.resolver.ts
+++ b/src/inventory/inventory.resolver.ts
@@ -1,5 +1,5 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Args, ID, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { InventoryItem } from './inventory.model';
 import { InventoryService } from './inventory.service';
 import { InventoryItemPipe } from './inventory.pipe';
@@ -62,5 +62,12 @@ export class InventoryResolver {
   async deleteInventoryItem(@Args('item', { type: () => ID }, InventoryItemPipe) item: InventoryItem): Promise<boolean> {
     await this.inventoryService.softDelete(item);
     return true;
+  }
+
+  /** Hard-delete all inventory items. Used before a full re-upload. */
+  @Mutation(() => Int, { description: 'Delete all inventory items (hard delete). Returns the number of items deleted.' })
+  @Roles(Role.DamplabStaff)
+  async deleteAllInventoryItems(): Promise<number> {
+    return this.inventoryService.deleteAll();
   }
 }

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -91,4 +91,10 @@ export class InventoryService {
   async softDelete(item: InventoryItem): Promise<void> {
     await this.inventoryModel.updateOne({ _id: (item as any).id ?? (item as any)._id }, { $set: { isDeleted: true } });
   }
+
+  /** Hard-delete every inventory item. Used before a full re-upload. */
+  async deleteAll(): Promise<number> {
+    const result = await this.inventoryModel.deleteMany({});
+    return result.deletedCount ?? 0;
+  }
 }

--- a/src/inventory/upload-log.model.ts
+++ b/src/inventory/upload-log.model.ts
@@ -1,0 +1,102 @@
+import { ObjectType, Field, ID, Int, InputType } from '@nestjs/graphql';
+import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
+import mongoose from 'mongoose';
+import JSON from 'graphql-type-json';
+
+/** A before/after snapshot for one item affected by an upload. */
+@ObjectType({ description: 'Before/after snapshot of a single inventory item affected by an upload.' })
+export class FieldSnapshot {
+  @Field(() => ID, { description: 'The inventory item id.' })
+  itemId: string;
+
+  @Field({ description: 'What happened: CREATE, UPDATE, REACTIVATE, or SKIP.' })
+  action: string;
+
+  @Field(() => JSON, { nullable: true, description: 'Field values before the change (null for creates).' })
+  before?: Record<string, unknown>;
+
+  @Field(() => JSON, { nullable: true, description: 'Field values after the change.' })
+  after?: Record<string, unknown>;
+}
+
+@InputType()
+export class FieldSnapshotInput {
+  @Field(() => ID)
+  itemId: string;
+
+  @Field()
+  action: string;
+
+  @Field(() => JSON, { nullable: true })
+  before?: Record<string, unknown>;
+
+  @Field(() => JSON, { nullable: true })
+  after?: Record<string, unknown>;
+}
+
+const FieldSnapshotSchema = new mongoose.Schema(
+  {
+    itemId: { type: mongoose.Schema.Types.ObjectId, ref: 'InventoryItem', required: true },
+    action: { type: String, required: true },
+    before: { type: mongoose.Schema.Types.Mixed },
+    after: { type: mongoose.Schema.Types.Mixed }
+  },
+  { _id: false }
+);
+
+/** An audit log entry for a bulk inventory upload. */
+@Schema({ timestamps: true })
+@ObjectType({ description: 'Audit log for a bulk inventory upload.' })
+export class UploadLog {
+  @Field(() => ID, { name: 'id', description: 'Database generated id.' })
+  id: string;
+
+  @Prop({ required: true })
+  @Field({ description: 'Display name of the uploader.' })
+  uploaderName: string;
+
+  @Prop({ required: false })
+  @Field({ nullable: true, description: 'Keycloak sub of the uploader.' })
+  uploaderSub?: string;
+
+  @Prop({ required: true })
+  @Field({ description: 'Original file name of the uploaded spreadsheet.' })
+  fileName: string;
+
+  @Prop({ required: true, default: () => new Date() })
+  @Field({ description: 'When the upload was performed.' })
+  uploadDate: Date;
+
+  @Prop({ required: true })
+  @Field(() => Int, { description: 'Total rows in the uploaded file.' })
+  rowCount: number;
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Int, { description: 'Items created.' })
+  createdCount: number;
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Int, { description: 'Items updated.' })
+  updatedCount: number;
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Int, { description: 'Items skipped.' })
+  skippedCount: number;
+
+  @Prop({ required: true, default: 0 })
+  @Field(() => Int, { description: 'Items that failed.' })
+  failedCount: number;
+
+  @Prop({ type: [String], default: [] })
+  @Field(() => [ID], { description: 'IDs of inventory items affected by this upload.' })
+  affectedItemIds: string[];
+
+  @Prop({ type: [FieldSnapshotSchema], default: [] })
+  @Field(() => [FieldSnapshot], { description: 'Per-item before/after snapshots.' })
+  fieldSnapshots: FieldSnapshot[];
+}
+
+export type UploadLogDocument = UploadLog & mongoose.Document;
+export const UploadLogSchema = SchemaFactory.createForClass(UploadLog);
+
+UploadLogSchema.index({ uploadDate: -1 });

--- a/src/inventory/upload-log.resolver.ts
+++ b/src/inventory/upload-log.resolver.ts
@@ -1,0 +1,67 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, ID, InputType, Field, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { UploadLog, FieldSnapshotInput } from './upload-log.model';
+import { UploadLogService } from './upload-log.service';
+import { AuthRolesGuard } from '../auth/auth.guard';
+import { Roles } from '../auth/roles/roles.decorator';
+import { Role } from '../auth/roles/roles.enum';
+
+@InputType()
+export class CreateUploadLogInput {
+  @Field()
+  uploaderName: string;
+
+  @Field({ nullable: true })
+  uploaderSub?: string;
+
+  @Field()
+  fileName: string;
+
+  @Field(() => Int)
+  rowCount: number;
+
+  @Field(() => Int)
+  createdCount: number;
+
+  @Field(() => Int)
+  updatedCount: number;
+
+  @Field(() => Int)
+  skippedCount: number;
+
+  @Field(() => Int)
+  failedCount: number;
+
+  @Field(() => [ID], { nullable: true })
+  affectedItemIds?: string[];
+
+  @Field(() => [FieldSnapshotInput], { nullable: true })
+  fieldSnapshots?: FieldSnapshotInput[];
+}
+
+@Resolver(() => UploadLog)
+@UseGuards(AuthRolesGuard)
+export class UploadLogResolver {
+  constructor(private readonly uploadLogService: UploadLogService) {}
+
+  @Query(() => [UploadLog], { description: 'All upload logs, newest first.' })
+  @Roles(Role.DamplabStaff)
+  async uploadLogs(): Promise<UploadLog[]> {
+    return this.uploadLogService.findAll();
+  }
+
+  @Query(() => UploadLog, { nullable: true, description: 'A single upload log by ID.' })
+  @Roles(Role.DamplabStaff)
+  async uploadLog(@Args('id', { type: () => ID }) id: string): Promise<UploadLog | null> {
+    return this.uploadLogService.findById(id);
+  }
+
+  @Mutation(() => UploadLog, { description: 'Record an upload log entry.' })
+  @Roles(Role.DamplabStaff)
+  async createUploadLog(@Args('input', { type: () => CreateUploadLogInput }) input: CreateUploadLogInput): Promise<UploadLog> {
+    return this.uploadLogService.create({
+      ...input,
+      uploadDate: new Date()
+    });
+  }
+}

--- a/src/inventory/upload-log.service.ts
+++ b/src/inventory/upload-log.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { UploadLog } from './upload-log.model';
+
+@Injectable()
+export class UploadLogService {
+  constructor(@InjectModel(UploadLog.name) private readonly model: Model<UploadLog>) {}
+
+  async create(input: Partial<UploadLog>): Promise<UploadLog> {
+    return this.model.create(input);
+  }
+
+  async findAll(): Promise<UploadLog[]> {
+    return this.model.find().sort({ uploadDate: -1 }).exec();
+  }
+
+  async findById(id: string): Promise<UploadLog | null> {
+    return this.model.findById(id).exec();
+  }
+}


### PR DESCRIPTION
## Inventory Upload Enhancements 

### Summary

Backend changes supporting the inventory bulk upload feature. Includes schema updates, new mutations, and an upload audit log.

**Changes:**

- **Public inventory query** — New `publicInventoryItems` query with `@Public()` decorator (no auth required). Strips `uniqueId` and `serialNumber` from results.

- **Type field: enum → free string** — Removed `InventoryItemType` enum (`ROBOT`, `MACHINE`, `INSTRUMENT`, `CONSUMABLE`, `OTHER`) and replaced with an unconstrained string field. Updated `booking.model.ts` (`inventoryType` snapshot field) and `booking.service.ts` (string literal comparison) accordingly. Default changed to `EQUIPMENT`.

- **`lastModifiedBy` field** — New optional string field on `InventoryItem` to track who last created or modified an item. Automatically available in create/update DTOs via `OmitType`/`PartialType` inheritance.

- **`deleteAllInventoryItems` mutation** — Staff-only mutation that hard-deletes all inventory items. Returns the count of deleted items. Used before a full re-upload to wipe existing data.

- **Upload log model & API** — New `UploadLog` schema with `FieldSnapshot` sub-documents for before/after tracking per item. Includes:
  - `UploadLogService` — `create`, `findAll`, `findById`
  - `UploadLogResolver` — `uploadLogs` query, `uploadLog(id)` query, `createUploadLog` mutation (all staff-only)
  - Registered in `InventoryModule`

### Changed files
- `src/inventory/inventory.model.ts` — Removed enum, free string type, added `lastModifiedBy`
- `src/inventory/inventory.service.ts` — Added `deleteAll()` method
- `src/inventory/inventory.resolver.ts` — Added `deleteAllInventoryItems` mutation, `publicInventoryItems` query
- `src/inventory/inventory.module.ts` — Registered UploadLog schema, service, resolver
- `src/inventory/upload-log.model.ts` — New: UploadLog + FieldSnapshot schemas
- `src/inventory/upload-log.service.ts` — New: CRUD service
- `src/inventory/upload-log.resolver.ts` — New: GraphQL resolver + CreateUploadLogInput
- `src/booking/booking.model.ts` — `inventoryType` changed from enum to string
- `src/booking/booking.service.ts` — Removed enum import, string literal comparison

### Frontend dependency
Corresponding frontend changes on `feature/inventory-bulk-upload` in `damplab-ui`.

### Test plan
- [ ] `publicInventoryItems` query returns active items without `uniqueId`/`serialNumber`, no auth required
- [ ] Create inventory item with custom type string (e.g. "FREEZER") — saves successfully
- [ ] `deleteAllInventoryItems` mutation wipes all items, returns correct count
- [ ] `createUploadLog` mutation saves log with field snapshots
- [ ] `uploadLogs` query returns logs sorted by date descending
- [ ] `uploadLog(id)` query returns full log with `fieldSnapshots` array
- [ ] Booking creation still correctly infers `TIMED` vs `QUANTITY` kind from string type
