### PR TITLE
feat(inventory): replace generic dimensions array with named L/W/H fi…

### DIFF
--- a/src/inventory/dtos/create.dto.ts
+++ b/src/inventory/dtos/create.dto.ts
@@ -2,15 +2,21 @@ import { Field, InputType, OmitType } from '@nestjs/graphql';
 import { InventoryItem, StationPlacementInput, DimensionInput } from '../inventory.model';
 
 /**
- * `placements` and `dimensions` must be re-declared: OmitType reuses the model's
+ * `placements` and `dimensionL/W/H` must be re-declared: OmitType reuses the model's
  * field metadata, and the model types them as @ObjectType classes, which are not
  * legal GraphQL inputs. Overriding them here binds the @InputType twins instead.
  */
 @InputType()
-export class CreateInventoryItem extends OmitType(InventoryItem, ['id', 'isDeleted', 'placements', 'dimensions'] as const, InputType) {
+export class CreateInventoryItem extends OmitType(InventoryItem, ['id', 'isDeleted', 'placements', 'dimensionL', 'dimensionW', 'dimensionH'] as const, InputType) {
   @Field(() => [StationPlacementInput], { nullable: true })
   placements?: StationPlacementInput[];
 
-  @Field(() => [DimensionInput], { nullable: true })
-  dimensions?: DimensionInput[];
+  @Field(() => DimensionInput, { nullable: true })
+  dimensionL?: DimensionInput;
+
+  @Field(() => DimensionInput, { nullable: true })
+  dimensionW?: DimensionInput;
+
+  @Field(() => DimensionInput, { nullable: true })
+  dimensionH?: DimensionInput;
 }

--- a/src/inventory/dtos/update.dto.ts
+++ b/src/inventory/dtos/update.dto.ts
@@ -1,12 +1,18 @@
 import { Field, InputType, OmitType, PartialType } from '@nestjs/graphql';
 import { InventoryItem, StationPlacementInput, DimensionInput } from '../inventory.model';
 
-/** See CreateInventoryItem for why `placements` and `dimensions` are re-declared rather than inherited. */
+/** See CreateInventoryItem for why `placements` and `dimensionL/W/H` are re-declared rather than inherited. */
 @InputType()
-export class InventoryItemChange extends PartialType(OmitType(InventoryItem, ['id', 'placements', 'dimensions'] as const), InputType) {
+export class InventoryItemChange extends PartialType(OmitType(InventoryItem, ['id', 'placements', 'dimensionL', 'dimensionW', 'dimensionH'] as const), InputType) {
   @Field(() => [StationPlacementInput], { nullable: true })
   placements?: StationPlacementInput[];
 
-  @Field(() => [DimensionInput], { nullable: true })
-  dimensions?: DimensionInput[];
+  @Field(() => DimensionInput, { nullable: true })
+  dimensionL?: DimensionInput;
+
+  @Field(() => DimensionInput, { nullable: true })
+  dimensionW?: DimensionInput;
+
+  @Field(() => DimensionInput, { nullable: true })
+  dimensionH?: DimensionInput;
 }

--- a/src/inventory/inventory.model.ts
+++ b/src/inventory/inventory.model.ts
@@ -187,9 +187,17 @@ export class InventoryItem {
   @Field({ nullable: true, description: 'Expiration date of the service contract, if any.' })
   serviceContractExpiration?: Date;
 
-  @Prop({ type: [DimensionSchema], default: [] })
-  @Field(() => [Dimension], { description: 'Physical dimensions of the equipment (up to 3 measurements).' })
-  dimensions: Dimension[];
+  @Prop({ type: DimensionSchema, required: false })
+  @Field(() => Dimension, { nullable: true, description: 'Length dimension.' })
+  dimensionL?: Dimension;
+
+  @Prop({ type: DimensionSchema, required: false })
+  @Field(() => Dimension, { nullable: true, description: 'Width dimension.' })
+  dimensionW?: Dimension;
+
+  @Prop({ type: DimensionSchema, required: false })
+  @Field(() => Dimension, { nullable: true, description: 'Height dimension.' })
+  dimensionH?: Dimension;
 
   @Prop({ required: false, default: false })
   @Field(() => Boolean, {


### PR DESCRIPTION
## Summary
- Replace generic `dimensions: Dimension[]` array with three optional named fields: `dimensionL`, `dimensionW`, `dimensionH` (each a `{value, unit}` object)
- Update create and update DTOs to accept the new fields as `DimensionInput`
- All three dimensions are optional — any combination can be null

## Test plan
- [ ] Create an inventory item with `dimensionL: { value: 1.5, unit: "m" }` via GraphQL — verify it saves and returns correctly
- [ ] Update an item setting only `dimensionW` — verify L and H remain null
- [ ] Query items — verify `dimensionL/W/H` resolve correctly (null when unset)
