### PR TITLE
fix(jobs): add clientEmail field so clients can access admin-submitte…

### DIFF
--- a/src/job/job.dto.ts
+++ b/src/job/job.dto.ts
@@ -6,13 +6,13 @@ import { JobService } from './job.service';
 
 @InputType()
 // CreateJobInput is what the user supplies, and what the CreateJobPipe receives.
-export class CreateJobInput extends PickType(Job, ['name', 'institute', 'notes', 'clientDisplayName'] as const, InputType) {
+export class CreateJobInput extends PickType(Job, ['name', 'institute', 'notes', 'clientDisplayName', 'clientEmail'] as const, InputType) {
   @Field(() => [AddWorkflowInput], { description: 'The workflows that were submitted together' })
   workflows: AddWorkflowInput[];
 }
 
 // CreateJobPreProcessed is what the pipe outputs.
-export interface CreateJobPreProcessed extends Pick<Job, 'name' | 'institute' | 'notes' | 'clientDisplayName' | 'state'> {
+export interface CreateJobPreProcessed extends Pick<Job, 'name' | 'institute' | 'notes' | 'clientDisplayName' | 'clientEmail' | 'state'> {
   workflows: AddWorkflowInputFull[];
 }
 

--- a/src/job/job.model.ts
+++ b/src/job/job.model.ts
@@ -90,6 +90,13 @@ export class Job {
   })
   clientDisplayName?: string;
 
+  @Prop({ required: false })
+  @Field({
+    description: 'Email of the actual client when a staff member submits on their behalf.',
+    nullable: true
+  })
+  clientEmail?: string;
+
   @Prop()
   @Field({ description: 'Subject id of the user - from access token' })
   sub: string;

--- a/src/job/job.resolver.ts
+++ b/src/job/job.resolver.ts
@@ -127,7 +127,7 @@ export class JobResolver {
     description: 'Paginated, filterable list of jobs for the current user (My Jobs).'
   })
   async ownJobs(@Args('input', { type: () => OwnJobsInput, nullable: true }) input: OwnJobsInput | null, @CurrentUser() user: User): Promise<OwnJobsResult> {
-    return this.jobService.findOwnJobsPaginated(user.sub, input ?? {});
+    return this.jobService.findOwnJobsPaginated(user.sub, user.email, input ?? {});
   }
 
   @Query(() => JobsResult, {
@@ -153,11 +153,9 @@ export class JobResolver {
   @Query(() => Job, { nullable: true })
   async ownJobById(@Args('id', { type: () => ID }) id: string, @CurrentUser() user: User): Promise<Job | null> {
     const job = await this.jobService.findById(id);
-    if (job?.sub === user.sub) {
-      return job;
-    } else {
-      return null;
-    }
+    if (job?.sub === user.sub) return job;
+    if (job?.clientEmail && user.email && job.clientEmail === user.email) return job;
+    return null;
   }
 
   @Query(() => Job)

--- a/src/job/job.service.ts
+++ b/src/job/job.service.ts
@@ -253,8 +253,8 @@ export class JobService {
     return { items, totalCount };
   }
 
-  async findOwnJobsPaginated(sub: string, input: OwnJobsInput): Promise<OwnJobsResult> {
-    const baseMatch = { sub };
+  async findOwnJobsPaginated(sub: string, email: string, input: OwnJobsInput): Promise<OwnJobsResult> {
+    const baseMatch = { $or: [{ sub }, { clientEmail: email }] };
     const { items, totalCount } = await this.runJobsPipeline(baseMatch, input);
     return { items, totalCount };
   }

--- a/src/sow/sow-access.ts
+++ b/src/sow/sow-access.ts
@@ -18,11 +18,12 @@ export function isStaff(user: User | undefined): boolean {
   return (user?.realm_access?.roles ?? []).includes(Role.DamplabStaff);
 }
 
-export function isJobOwner(job: { email?: string; sub?: string } | null | undefined, user: User | undefined): boolean {
+export function isJobOwner(job: { email?: string; sub?: string; clientEmail?: string } | null | undefined, user: User | undefined): boolean {
   if (!job || !user) return false;
   // Guard against a job with no owner fields matching a user with none either.
   if (job.sub && user.sub && job.sub === user.sub) return true;
   if (job.email && user.email && job.email === user.email) return true;
+  if (job.clientEmail && user.email && job.clientEmail === user.email) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Add optional `clientEmail` field to Job model for staff-submitted jobs
- Update `ownJobs` query to match on `clientEmail` via `$or` so clients see admin-submitted jobs in "My Jobs"
- Update `ownJobById` to also grant access when `clientEmail` matches the caller's email
- Update SOW `isJobOwner` access check to recognize `clientEmail` as a valid ownership signal
- Add `clientEmail` to `CreateJobInput` and `CreateJobPreProcessed` DTOs

## Bug
When staff submits a job on behalf of a client, the job's `sub` and `email` are set to the staff member's identity. The client cannot see the job in "My Jobs" or access its SOW.

## Fix
Store the client's email in a new `clientEmail` field. Client-side access checks (`ownJobs`, `ownJobById`, SOW read) now also match on `clientEmail`. Staff access is unaffected — they use `allJobs` and `isStaff()`.

## Test Plan
- [ ] Staff submits job with client email → `clientEmail` field populated on the job document
- [ ] Client logs in → job appears in "My Jobs"
- [ ] Client clicks job → `ownJobById` returns the job
- [ ] Client views SOW → access granted via `isJobOwner`
- [ ] Staff still has full access to all jobs and SOWs
- [ ] Regular client-submitted jobs still work as before (`clientEmail` is null)

ClickUp: https://app.clickup.com/t/14225407/868kxgmq8
